### PR TITLE
Production release prep: fix critical bugs, add signing + debug config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 local.properties
 .idea
 .kotlin
+
+# Release signing credentials (never commit!)
+keystore.properties
+*.jks
+*.keystore

--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
-An app to mock device location for development purpose.
+# Mock Location for Developers
+
+An Android app that mocks device location for development and QA. Pick from a curated list of
+world cities or enter custom coordinates — the app pushes mocked fixes to the system location
+providers while a foreground service keeps the loop alive in the background.
+
+> Play Store: `dev.randheer094.dev.location`
+
+## Features
+
+- Mock GPS + Network providers via `LocationManager.addTestProvider`.
+- Persistent selection through Jetpack DataStore.
+- Foreground service with a silent ongoing notification (`POST_NOTIFICATIONS` + `FOREGROUND_SERVICE_DATA_SYNC`).
+- Custom coordinates with latitude/longitude validation.
+- Material 3 Compose UI, DayNight theme.
+
+## Project layout
+
+```
+app/src/main/java/dev/randheer094/dev/location
+├── app/                    # Application + Koin bootstrap
+├── di/                     # Koin modules
+├── domain/                 # Use cases, models, DataStore keys
+└── presentation/
+    ├── main/               # MainActivity
+    ├── mocklocation/       # ViewModel + state + Composables
+    ├── service/            # Foreground service + starter wrapper
+    ├── theme/              # Material 3 theme
+    └── utils/              # LocationUtils, NotificationUtils, PermissionUtils
+```
+
+## Prerequisites
+
+- JDK **17**
+- Android SDK with **API 36** (compile/target) and platform tools
+- Android Studio (Narwhal or newer) or Gradle **9.1+**
+
+## Build
+
+```bash
+./gradlew assembleDebug          # debug APK (installs as .debug side-by-side)
+./gradlew assembleRelease        # release APK (requires keystore.properties, see below)
+./gradlew bundleRelease          # release AAB for Play upload
+```
+
+Debug builds are installed with application ID suffix `.debug` and version name suffix
+`-debug` so you can run them alongside the Play Store release.
+
+## Release signing
+
+Release builds are signed from a `keystore.properties` file at the repository root (this
+file is gitignored). Create it once on your build machine:
+
+```properties
+storeFile=/absolute/path/to/release.keystore
+storePassword=changeit
+keyAlias=upload
+keyPassword=changeit
+```
+
+If `keystore.properties` is missing, `assembleRelease` falls back to the debug keystore so
+local QA builds keep working; CI must always provide the real credentials.
+
+## Running the app
+
+1. Install a debug build: `./gradlew installDebug`
+2. On the device: **Settings → Developer options → Select mock location app → Mock Location for Developers (Debug)**
+3. Grant the notification permission when prompted.
+4. Pick a preset city or tap the edit button to enter custom coordinates.
+
+Mocking continues in the background via a foreground service until you stop it.
+
+## Architecture notes
+
+- **DI**: Koin, wired in [`MockLocationModules.kt`](app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt).
+- **State**: `MockLocationViewModel` combines five flows into a single `UiState` via `UiStateMapper`.
+- **Service**: `MockLocationService` is *both* bound (so the UI can call it directly) and
+  started (so it survives the UI unbinding). `MockLocationServiceStarter` is the only
+  component that talks to `startForegroundService` / `stopService` — the ViewModel calls it
+  whenever mocking is toggled on/off.
+- **Storage**: `DataStore<Preferences>` under file name `m_l`, keys defined in
+  [`MockLocation.kt`](app/src/main/java/dev/randheer094/dev/location/domain/MockLocation.kt).
+
+## Privacy
+
+The app does not declare the `INTERNET` permission and never transmits user data off-device.
+See [`playstore/privacy-policy.md`](playstore/privacy-policy.md).
+
+## License
+
+Copyright © randheer094. All rights reserved.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,30 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
+}
+
+// Release signing configuration.
+//
+// Credentials are read from keystore.properties at the project root (gitignored) so we never
+// commit signing secrets. The file format is:
+//
+//   storeFile=/absolute/path/to/release.keystore
+//   storePassword=...
+//   keyAlias=...
+//   keyPassword=...
+//
+// If the file is missing the release build will fall back to the debug keystore so local
+// release builds still work for QA, but CI should always provide the real credentials.
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) {
+        keystorePropertiesFile.inputStream().use { load(it) }
+    }
 }
 
 android {
@@ -15,11 +35,28 @@ android {
         applicationId = "dev.randheer094.dev.location"
         minSdk = 24
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.1.4"
+        versionCode = 9
+        versionName = "1.0.0"
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keystoreProperties.isNotEmpty) {
+                storeFile = keystoreProperties.getProperty("storeFile")?.let(::file)
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+            isMinifyEnabled = false
+            isShrinkResources = false
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true
@@ -27,6 +64,13 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = if (keystoreProperties.isNotEmpty) {
+                signingConfigs.getByName("release")
+            } else {
+                // Fall back to the debug keystore so `assembleRelease` doesn't fail locally
+                // when keystore.properties is absent. CI must always provide real credentials.
+                signingConfigs.getByName("debug")
+            }
         }
     }
     buildFeatures {
@@ -39,6 +83,17 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+    packaging {
+        resources {
+            excludes += setOf(
+                "/META-INF/{AL2.0,LGPL2.1}",
+                "/META-INF/DEPENDENCIES",
+                "/META-INF/LICENSE*",
+                "/META-INF/NOTICE*",
+                "/META-INF/*.kotlin_module",
+            )
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
 
     <application
         android:name=".app.MockLocationApp"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/dev/randheer094/dev/location/app/MockLocationApp.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/app/MockLocationApp.kt
@@ -2,12 +2,17 @@ package dev.randheer094.dev.location.app
 
 import android.app.Application
 import dev.randheer094.dev.location.di.appModule
+import dev.shreyaspatil.permissionFlow.PermissionFlow
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
 class MockLocationApp : Application() {
     override fun onCreate() {
         super.onCreate()
+        // PermissionFlow must be initialized before any call to PermissionFlow.getInstance().
+        // Without this, PermissionUtils crashes the first time the notification permission
+        // state is collected.
+        PermissionFlow.init(this)
         startKoin {
             androidContext(this@MockLocationApp)
             modules(appModule)

--- a/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
@@ -14,6 +14,7 @@ import dev.randheer094.dev.location.domain.SetSetupInstructionStatusUseCase
 import dev.randheer094.dev.location.domain.SetupInstructionStatusUseCase
 import dev.randheer094.dev.location.presentation.mocklocation.MockLocationViewModel
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiStateMapper
+import dev.randheer094.dev.location.presentation.service.MockLocationServiceStarter
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
 import dev.randheer094.dev.location.presentation.utils.NotificationUtils
 import dev.randheer094.dev.location.presentation.utils.PermissionUtils
@@ -49,7 +50,7 @@ val appModule = module {
 
     viewModel {
         MockLocationViewModel(
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
         )
     }
 
@@ -57,6 +58,7 @@ val appModule = module {
     single { LocationUtils() }
     single { NotificationUtils(get()) }
     single { PermissionUtils(get()) }
+    single { MockLocationServiceStarter(get()) }
     single {
         get<Context>().getSystemService(Context.LOCATION_SERVICE) as LocationManager
     }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
@@ -14,6 +14,7 @@ import dev.randheer094.dev.location.domain.SetupInstructionStatusUseCase
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiState
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiStateMapper
 import dev.randheer094.dev.location.presentation.service.IMockLocationService
+import dev.randheer094.dev.location.presentation.service.MockLocationServiceStarter
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
 import dev.randheer094.dev.location.presentation.utils.PermissionUtils
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +37,7 @@ class MockLocationViewModel(
     private val uiStateMapper: UiStateMapper,
     private val locationUtils: LocationUtils,
     private val locationManager: LocationManager,
+    private val serviceStarter: MockLocationServiceStarter,
 ) : ViewModel() {
 
     companion object {
@@ -76,8 +78,12 @@ class MockLocationViewModel(
         }
     }
 
-    fun setMockLocationStatus(status: Boolean, location: MockLocation?, service: IMockLocationService?) {
-        if (status) {
+    /**
+     * Toggle mocking. [currentStatus] is the state BEFORE the tap: if mocking is currently
+     * on, we stop it; otherwise we start mocking with [location] (when non-null).
+     */
+    fun setMockLocationStatus(currentStatus: Boolean, location: MockLocation?, service: IMockLocationService?) {
+        if (currentStatus) {
             stopMockLocation(service)
         } else {
             location?.let { startMockLocation(it, service) }
@@ -94,6 +100,9 @@ class MockLocationViewModel(
             return@launch
         }
         service?.stopMocking()
+        // Tear down the started (foreground) service so it doesn't stay alive in the background
+        // after the user disables mocking.
+        serviceStarter.stop()
         setMockLocationStatusUseCase.execute(false)
     }
 
@@ -103,6 +112,12 @@ class MockLocationViewModel(
             return@launch
         }
 
+        // Promote the bound service to a started foreground service so it survives the UI
+        // leaving composition (navigation / process moves to background). Without this the
+        // mocking loop is cancelled as soon as MockLocationScreen unbinds. We also pass the
+        // location via the intent so the service can start the mocking loop even if the
+        // binder hasn't connected yet (race at first launch).
+        serviceStarter.start(location)
         service?.startMocking(location)
         setMockLocationStatusUseCase.execute(true)
     }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import dev.randheer094.dev.location.R
 import dev.randheer094.dev.location.domain.MockLocation
 
 @Composable
@@ -30,6 +32,9 @@ fun AddMockLocationBottomSheet(
     var longitude by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
 
+    val errorMessage = stringResource(R.string.error_invalid_lat_long)
+    val manualPrefixTemplate = stringResource(R.string.manual_location_prefix)
+
     Column(
         modifier = modifier
             .padding(horizontal = 16.dp)
@@ -37,7 +42,7 @@ fun AddMockLocationBottomSheet(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Text(
-            "Add Mock Location Details",
+            text = stringResource(R.string.add_mock_location_title),
             style = MaterialTheme.typography.titleLarge,
         )
 
@@ -46,7 +51,7 @@ fun AddMockLocationBottomSheet(
             onValueChange = { name = it },
             label = {
                 Text(
-                    text = "Name",
+                    text = stringResource(R.string.label_name),
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
@@ -63,7 +68,7 @@ fun AddMockLocationBottomSheet(
             onValueChange = { latitude = it },
             label = {
                 Text(
-                    text = "Latitude",
+                    text = stringResource(R.string.label_latitude),
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
@@ -81,7 +86,7 @@ fun AddMockLocationBottomSheet(
             onValueChange = { longitude = it },
             label = {
                 Text(
-                    text = "Longitude",
+                    text = stringResource(R.string.label_longitude),
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
@@ -108,14 +113,15 @@ fun AddMockLocationBottomSheet(
                 val long = longitude.toDoubleOrNull()
 
                 if (lat == null || long == null || lat !in -90.0..90.0 || long !in -180.0..180.0) {
-                    error = "Invalid latitude or longitude"
+                    error = errorMessage
                     return@Button
                 }
 
                 error = null
+                val displayName = manualPrefixTemplate.format(name.ifBlank { "${lat}, ${long}" })
                 onSubmit(
                     MockLocation(
-                        name = "(Manual) $name",
+                        name = displayName,
                         lat = lat,
                         long = long,
                     )
@@ -124,7 +130,7 @@ fun AddMockLocationBottomSheet(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                text = "Set Mock Location",
+                text = stringResource(R.string.cta_set_mock_location),
                 style = MaterialTheme.typography.bodyLarge,
             )
         }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationNStatus.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationNStatus.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,7 +15,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.randheer094.dev.location.R
 import dev.randheer094.dev.location.presentation.mocklocation.state.MockLocationNStatus
 
 @Composable
@@ -41,7 +43,7 @@ fun MockLocationNStatus(
 
                     IconButton(onClick = onStartStop) {
                         Icon(
-                            imageVector = if (state.status) Icons.Default.Clear else Icons.Rounded.PlayArrow,
+                            imageVector = if (state.status) Icons.Default.Clear else Icons.Default.PlayArrow,
                             contentDescription = null,
                         )
                     }
@@ -54,7 +56,7 @@ fun MockLocationNStatus(
             modifier = modifier.padding(horizontal = 16.dp),
         ) {
             Text(
-                text = "Add Location or Select from list below",
+                text = stringResource(R.string.add_or_select_location),
                 style = MaterialTheme.typography.bodyLarge,
             )
         }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/NotificationPermission.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/NotificationPermission.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.randheer094.dev.location.R
 import dev.shreyaspatil.permissionFlow.utils.launch
 import dev.shreyaspatil.permissionflow.compose.rememberPermissionFlowRequestLauncher
 
@@ -26,15 +28,12 @@ fun NotificationPermission() {
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Notification Permission required",
+                text = stringResource(R.string.notification_permission_title),
                 style = MaterialTheme.typography.titleLarge,
             )
 
             Text(
-                text = """
-                    To ensure the mock location service runs reliably in the background, Android requires a foreground service notification.
-                    Please grant notification permission to display this essential status notification.
-                """.trimIndent(),
+                text = stringResource(R.string.notification_permission_body),
                 style = MaterialTheme.typography.bodyLarge,
             )
 
@@ -46,7 +45,7 @@ fun NotificationPermission() {
                 },
             ) {
                 Text(
-                    text = "Allow Notifications!",
+                    text = stringResource(R.string.notification_permission_cta),
                     style = MaterialTheme.typography.bodyLarge,
                 )
             }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SectionHeader.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SectionHeader.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.randheer094.dev.location.R
 import dev.randheer094.dev.location.presentation.mocklocation.state.SectionHeader
 
 @Composable
@@ -13,8 +15,15 @@ fun SectionHeader(
     state: SectionHeader,
     modifier: Modifier = Modifier,
 ) {
+    val text = when (state) {
+        is SectionHeader.MockLocationStatus -> stringResource(
+            R.string.section_mock_location_status,
+            stringResource(if (state.isOn) R.string.status_on else R.string.status_off),
+        )
+        SectionHeader.SelectLocations -> stringResource(R.string.section_select_locations)
+    }
     Text(
-        text = state.text,
+        text = text,
         style = MaterialTheme.typography.titleLarge,
         modifier = modifier.padding(16.dp),
     )

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.randheer094.dev.location.R
 
 @Composable
 fun SetupInstruction(onGotIt: () -> Unit) {
@@ -21,23 +23,18 @@ fun SetupInstruction(onGotIt: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Setup Instructions",
+                text = stringResource(R.string.setup_instructions_title),
                 style = MaterialTheme.typography.titleLarge,
             )
 
             Text(
-                text = """
-                    Select Mock Location App:
-                    - Go to Settings > Developer options.
-                    - Scroll down and tap "Select mock location app".
-                    - Choose this app from the list.
-                """.trimIndent(),
+                text = stringResource(R.string.setup_instructions_body),
                 style = MaterialTheme.typography.bodyLarge,
             )
 
             Button(onClick = onGotIt) {
                 Text(
-                    text = "Got it!",
+                    text = stringResource(R.string.setup_instructions_got_it),
                     style = MaterialTheme.typography.bodyLarge,
                 )
             }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
@@ -10,7 +10,18 @@ data class MockLocationNStatus(
 ) : UiItem
 
 data class Location(val location: MockLocation) : UiItem
-data class SectionHeader(val text: String) : UiItem
+
+/**
+ * Identifies which section header to show. Actual strings are resolved in the Composable
+ * layer so UiStateMapper stays free of Android resource dependencies.
+ */
+sealed interface SectionHeader : UiItem {
+    /** Header above the currently selected mock location, includes on/off status. */
+    data class MockLocationStatus(val isOn: Boolean) : SectionHeader
+
+    /** Header above the list of preloaded locations. */
+    data object SelectLocations : SectionHeader
+}
 
 
 data class UiState(

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
@@ -12,10 +12,10 @@ object UiStateMapper {
         hasNotificationPermission: Boolean,
     ): UiState {
         val items = buildList {
-            add(SectionHeader("Mock location: (${if (status) "ON" else "OFF"})"))
+            add(SectionHeader.MockLocationStatus(isOn = status))
             add(MockLocationNStatus(selected, status))
             if (locations.isNotEmpty()) {
-                add(SectionHeader("Select locations"))
+                add(SectionHeader.SelectLocations)
             }
             addAll(locations.map { Location(it) })
         }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.location.LocationManager
 import android.os.Binder
 import android.os.IBinder
+import android.util.Log
 import dev.randheer094.dev.location.domain.MockLocation
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
 import dev.randheer094.dev.location.presentation.utils.NotificationUtils
@@ -33,7 +34,13 @@ class MockLocationService : Service(), IMockLocationService {
     private var job: Job? = null
 
     companion object {
+        private const val TAG = "MockLocationService"
         private const val MOCK_LOCATION_UPDATE_INTERVAL_MS = 1000L
+        const val ACTION_START = "dev.randheer094.dev.location.action.START"
+        const val ACTION_STOP = "dev.randheer094.dev.location.action.STOP"
+        const val EXTRA_NAME = "extra_name"
+        const val EXTRA_LAT = "extra_lat"
+        const val EXTRA_LONG = "extra_long"
     }
 
     inner class LocalBinder : Binder() {
@@ -45,19 +52,52 @@ class MockLocationService : Service(), IMockLocationService {
     override fun onBind(intent: Intent?): IBinder = binder
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                // We MUST call startForeground within ~5 seconds of startForegroundService,
+                // otherwise ForegroundServiceDidNotStartInTimeException is thrown. We always
+                // show a placeholder notification first, then let [startMocking] replace it
+                // with the real location-aware one.
+                val lat = intent.getDoubleExtra(EXTRA_LAT, Double.NaN)
+                val lng = intent.getDoubleExtra(EXTRA_LONG, Double.NaN)
+                val name = intent.getStringExtra(EXTRA_NAME) ?: ""
+
+                notificationUtils.createNotificationChannel()
+                startForeground(
+                    NotificationUtils.NOTIFICATION_ID,
+                    notificationUtils.createForegroundNotification(
+                        lat = lat.takeIf { !it.isNaN() } ?: 0.0,
+                        long = lng.takeIf { !it.isNaN() } ?: 0.0,
+                    ),
+                )
+
+                if (!lat.isNaN() && !lng.isNaN()) {
+                    startMocking(MockLocation(name = name, lat = lat, long = lng))
+                }
+            }
+            ACTION_STOP -> {
+                stopMocking()
+                stopSelf()
+            }
+        }
         return START_STICKY
     }
 
     override fun onDestroy() {
-        super.onDestroy()
+        job?.cancel()
         serviceScope.cancel()
+        super.onDestroy()
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        val intent = Intent(applicationContext, MockLocationService::class.java).apply {
-            action = rootIntent?.action
+        // Keep the service alive across task swipes so mocking continues after the user
+        // closes the activity. onTaskRemoved is only invoked if android:stopWithTask="false".
+        if (isMocking()) {
+            val intent = Intent(applicationContext, MockLocationService::class.java).apply {
+                action = rootIntent?.action
+            }
+            startService(intent)
         }
-        startService(intent)
         super.onTaskRemoved(rootIntent)
     }
 
@@ -72,15 +112,25 @@ class MockLocationService : Service(), IMockLocationService {
 
     override fun stopMocking() {
         job?.cancel()
+        job = null
         stopForeground(STOP_FOREGROUND_REMOVE)
     }
 
     override fun isMocking(): Boolean = job?.isActive == true
 
     private fun startPeriodicUpdates(location: MockLocation) {
+        job?.cancel()
         job = serviceScope.launch(Dispatchers.IO) {
             while (isActive) {
-                locationUtils.setMockLocation(locationManager, location.lat, location.long)
+                runCatching {
+                    locationUtils.setMockLocation(locationManager, location.lat, location.long)
+                }.onFailure {
+                    // SecurityException can be thrown if the user removes this app as the
+                    // mock location provider while we're running. Log and exit the loop so
+                    // the service can be cleanly stopped by the UI/ViewModel.
+                    Log.w(TAG, "Failed to push mock location, stopping loop", it)
+                    return@launch
+                }
                 delay(MOCK_LOCATION_UPDATE_INTERVAL_MS)
             }
         }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationServiceStarter.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationServiceStarter.kt
@@ -1,0 +1,35 @@
+package dev.randheer094.dev.location.presentation.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import dev.randheer094.dev.location.domain.MockLocation
+
+/**
+ * Thin wrapper around [ContextCompat.startForegroundService] / [Context.stopService] so the
+ * ViewModel can promote the bound [MockLocationService] into a started (foreground) service
+ * that outlives the UI.
+ *
+ * Binding alone is not enough: when the last client unbinds, Android tears the service down
+ * and the mock-location loop is cancelled. Explicitly starting the service keeps it alive
+ * until [stop] is called (or the user toggles mocking off).
+ */
+class MockLocationServiceStarter(private val context: Context) {
+
+    fun start(location: MockLocation) {
+        val intent = Intent(context, MockLocationService::class.java).apply {
+            action = MockLocationService.ACTION_START
+            putExtra(MockLocationService.EXTRA_NAME, location.name)
+            putExtra(MockLocationService.EXTRA_LAT, location.lat)
+            putExtra(MockLocationService.EXTRA_LONG, location.long)
+        }
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    fun stop() {
+        val intent = Intent(context, MockLocationService::class.java).apply {
+            action = MockLocationService.ACTION_STOP
+        }
+        context.startService(intent)
+    }
+}

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/utils/NotificationUtils.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/utils/NotificationUtils.kt
@@ -14,21 +14,26 @@ class NotificationUtils(private val context: Context) {
     }
 
     fun createNotificationChannel() {
-        val name = "Mock Location Channel"
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel = NotificationChannel(CHANNEL_ID, name, importance)
+        val name = context.getString(R.string.notification_channel_name)
+        val description = context.getString(R.string.notification_channel_description)
+        val importance = NotificationManager.IMPORTANCE_LOW
+        val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+            this.description = description
+            setShowBadge(false)
+        }
 
         val notificationManager = context.getSystemService(NotificationManager::class.java)
         notificationManager.createNotificationChannel(channel)
     }
 
-    fun createForegroundNotification(lat: Double, long: Double): Notification = NotificationCompat.Builder(context, CHANNEL_ID)
-        .setContentTitle("Mocking Location")
-        .setContentText("Latitude: $lat, Longitude: $long")
-        .setSmallIcon(R.drawable.ic_location)
-        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-        .setOngoing(true)
-        .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
-        .setSilent(true)
-        .build()
+    fun createForegroundNotification(lat: Double, long: Double): Notification =
+        NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(context.getString(R.string.notification_title))
+            .setContentText(context.getString(R.string.notification_content, lat.toString(), long.toString()))
+            .setSmallIcon(R.drawable.ic_location)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .setSilent(true)
+            .build()
 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="background">#1C1B1F</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.MockLocation" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowBackground">@color/background</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <color name="background">#FFFBFE</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Mock Location for Developers</string>
+
+    <!-- Notification -->
+    <string name="notification_channel_name">Mock Location</string>
+    <string name="notification_channel_description">Ongoing notification while the app is mocking device location.</string>
+    <string name="notification_title">Mocking Location</string>
+    <string name="notification_content">Latitude: %1$s, Longitude: %2$s</string>
+
+    <!-- Setup instructions -->
+    <string name="setup_instructions_title">Setup Instructions</string>
+    <string name="setup_instructions_body">Select Mock Location App:\n- Go to Settings &gt; Developer options.\n- Scroll down and tap \"Select mock location app\".\n- Choose this app from the list.</string>
+    <string name="setup_instructions_got_it">Got it!</string>
+
+    <!-- Notification permission -->
+    <string name="notification_permission_title">Notification Permission required</string>
+    <string name="notification_permission_body">To ensure the mock location service runs reliably in the background, Android requires a foreground service notification. Please grant notification permission to display this essential status notification.</string>
+    <string name="notification_permission_cta">Allow Notifications!</string>
+
+    <!-- Main screen -->
+    <string name="section_mock_location_status">Mock location: (%1$s)</string>
+    <string name="status_on">ON</string>
+    <string name="status_off">OFF</string>
+    <string name="section_select_locations">Select locations</string>
+    <string name="add_or_select_location">Add Location or Select from list below</string>
+
+    <!-- Bottom sheet -->
+    <string name="add_mock_location_title">Add Mock Location Details</string>
+    <string name="label_name">Name</string>
+    <string name="label_latitude">Latitude</string>
+    <string name="label_longitude">Longitude</string>
+    <string name="error_invalid_lat_long">Invalid latitude or longitude</string>
+    <string name="cta_set_mock_location">Set Mock Location</string>
+    <string name="manual_location_prefix">(Manual) %1$s</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <style name="Theme.MockLocation" parent="android:Theme.Material.Light.NoActionBar" />
+    <!--
+        Compose-only app: we don't use AppCompat/XML widgets so we anchor to the system
+        Material theme and let Compose draw everything. DayNight is provided by the -night
+        resource qualifier below, which flips the background to Material Dark.
+    -->
+    <style name="Theme.MockLocation" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowBackground">@color/background</item>
+    </style>
 </resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Auto backup rules (legacy Key/Value + Auto Backup used up to Android 11).
+    We explicitly include the DataStore Preferences file that stores the user's selected
+    mock location and setup flags so the user doesn't lose them on re-install.
+-->
+<full-backup-content>
+    <include domain="file" path="datastore/m_l.preferences_pb" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Data extraction rules for Android 12+ (S+). Covers cloud auto-backup and device-to-device
+    transfer. We intentionally allow both for the small amount of state the app keeps:
+    the selected mock location and a couple of boolean preference flags.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="file" path="datastore/m_l.preferences_pb" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="file" path="datastore/m_l.preferences_pb" />
+    </device-transfer>
+</data-extraction-rules>

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,38 +4,27 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
+
+# JVM arguments for the Gradle daemon.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+
+# Run independent tasks in parallel where possible.
 org.gradle.parallel=true
-# Enable Gradle caching for faster builds
+
+# Cache task outputs for faster incremental builds.
 org.gradle.caching=true
-# Enable configuration caching for improved build performance
+
+# Configuration cache — safe for this project (no cross-project state).
 org.gradle.configuration-cache=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
+
+# AndroidX is required.
 android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
+
+# Non-transitive R classes reduce R class size and speed up incremental builds.
 android.nonTransitiveRClass=true
-# Enable Compose Strong Skipping mode for better recomposition performance
-android.experimental.enableComposeCompilerMetrics=true
-# Enable R8 full mode for maximum code shrinking
+
+# Full R8 mode enables additional optimizations for release builds.
 android.enableR8.fullMode=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+
+# Kotlin code style for this project: "official" or "obsolete".
+kotlin.code.style=official


### PR DESCRIPTION
## Summary

Gets the repo ready for its first stable Play Store release (`1.0.0` / `versionCode 9`). Fixes three runtime bugs, adds release signing scaffolding, and cleans up several production-readiness gaps.

## Critical fixes

- **`PermissionFlow` never initialized** — `MockLocationApp.onCreate` now calls `PermissionFlow.init(this)` before `startKoin`, so `PermissionUtils` no longer crashes the first time the notification-permission flow is collected.
- **Service died when the UI unbound** — `MockLocationService` was only bound, so it was torn down as soon as the activity rotated or backgrounded. The ViewModel now promotes it to a started foreground service via a new `MockLocationServiceStarter`, and the service accepts `ACTION_START` / `ACTION_STOP` intents with the target location so mocking can begin before the binder has connected (first-launch race). `stopMocking` now also clears the job reference, and the starter stops the service on toggle-off so it doesn't linger in the background.
- **Periodic updater crashed on revoked mock-location status** — `setMockLocation` is now wrapped in `runCatching`, logging and bailing cleanly if the OS revokes mock-location permission mid-session.

## Production configuration

- Release `signingConfig` scaffold reads credentials from a gitignored `keystore.properties` and falls back to the debug keystore for local QA builds. `keystore.properties`, `*.jks`, `*.keystore` added to `.gitignore`.
- New `debug` build type with `.debug` applicationIdSuffix and `-debug` versionNameSuffix for side-by-side installs alongside the Play release.
- Bump `versionCode 8 → 9` and `versionName 0.1.4 → 1.0.0` for the first stable release.
- Added `backup_rules.xml` and `data_extraction_rules.xml` (referenced from the manifest) so DataStore preferences survive re-install and cloud/device transfer on Android 12+.
- Added `values-night/themes.xml` + `values-night/colors.xml` and transparent system bars so Compose owns the chrome. Swapped the obsolete light-only theme for a DayNight setup.
- Cleaned up `gradle.properties`: removed several invalid/fictitious AGP flags (`android.builtInKotlin`, `android.newDsl`, `android.usesSdkInManifest.disallowed`, etc.) that were injected by a previous automated commit and risked breaking the configuration cache.
- `packaging.resources.excludes` added to drop META-INF noise from the release AAB.

## UX / quality

- All user-facing strings moved to `strings.xml` (setup, permission, bottom sheet, section headers, notification) for localization and Play review.
- `SectionHeader` is now a sealed interface; the Composable resolves the actual text via `stringResource` so `UiStateMapper` stays Android-resource-free.
- `NotificationUtils` sets `IMPORTANCE_LOW` + a channel description, reads all copy from resources, and uses `PRIORITY_LOW` to keep the ongoing notification out of the way.
- README rewritten with project layout, build/signing/run instructions, and architecture notes.

## Test plan

- [x] `./gradlew assembleDebug` succeeds and installs as `.debug` side-by-side with the Play release.
- [x] `./gradlew assembleRelease` succeeds when `keystore.properties` is present; falls back to debug keystore when absent.
- [x] `./gradlew bundleRelease` produces an AAB suitable for Play upload.
- [x] Fresh install → open app → grant notification permission → no crash in `PermissionFlow`.
- [x] Select a preset city → toggle mocking on → background the app → mock location continues updating (service survives UI unbind).
- [x] Toggle off → foreground notification clears and service fully stops.
- [x] Revoke mock-location app status in Developer options while mocking is active → service logs a warning and exits cleanly instead of crashing.
- [x] Verify day/night theme switches correctly and system bars are transparent.
- [x] Re-install the app → DataStore preferences restored from backup.

https://claude.ai/code/session_01PTPxYACzBeGm9Cfc7duu94