### PR TITLE
ARC-149: Add elapsed timer and selected location to UiState

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
@@ -50,7 +50,7 @@ val appModule = module {
 
     viewModel {
         MockLocationViewModel(
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
         )
     }
 

--- a/app/src/main/java/dev/randheer094/dev/location/domain/MockLocation.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/domain/MockLocation.kt
@@ -1,6 +1,7 @@
 package dev.randheer094.dev.location.domain
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,3 +16,4 @@ data class MockLocation(
 val SELECTED_MOCK_LOCATION = stringPreferencesKey("m_l")
 val MOCK_LOCATION_STATUS = booleanPreferencesKey("m_l_e")
 val SETUP_INSTRUCTION_STATUS = booleanPreferencesKey("setup")
+val MOCK_STARTED_AT = longPreferencesKey("mock_started_at")

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
@@ -1,9 +1,13 @@
 package dev.randheer094.dev.location.presentation.mocklocation
 
 import android.location.LocationManager
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.randheer094.dev.location.domain.GetMockLocationsUseCase
+import dev.randheer094.dev.location.domain.MOCK_STARTED_AT
 import dev.randheer094.dev.location.domain.MockLocation
 import dev.randheer094.dev.location.domain.MockLocationStatusUseCase
 import dev.randheer094.dev.location.domain.SelectMockLocationUseCase
@@ -18,10 +22,15 @@ import dev.randheer094.dev.location.presentation.service.MockLocationServiceStar
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
 import dev.randheer094.dev.location.presentation.utils.PermissionUtils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -38,25 +47,46 @@ class MockLocationViewModel(
     private val locationUtils: LocationUtils,
     private val locationManager: LocationManager,
     private val serviceStarter: MockLocationServiceStarter,
+    private val dataStore: DataStore<Preferences>,
 ) : ViewModel() {
 
     companion object {
         private const val STOP_TIMEOUT_MILLIS = 5_000L
     }
 
+    private val elapsedLabelFlow: Flow<String> = dataStore.data
+        .map { it[MOCK_STARTED_AT] ?: 0L }
+        .flatMapLatest { startedAt ->
+            if (startedAt == 0L) {
+                flow { emit("") }
+            } else {
+                flow {
+                    while (true) {
+                        val elapsed = System.currentTimeMillis() - startedAt
+                        emit(formatElapsed(elapsed))
+                        delay(1000)
+                    }
+                }
+            }
+        }
+
     val state = combine(
-        setupInstructionStatusUseCase.execute(),
-        mockLocationStatusUseCase.execute(),
-        selectedMockLocationUseCase.execute(),
+        combine(
+            setupInstructionStatusUseCase.execute(),
+            mockLocationStatusUseCase.execute(),
+            selectedMockLocationUseCase.execute(),
+        ) { showInstructions, status, selected -> Triple(showInstructions, status, selected) },
         getMockLocationsUseCase.execute(),
         permissionUtils.getNotificationPermissionState(),
-    ) { showInstructions, status, selected, locations, notiPermissionState ->
+        elapsedLabelFlow,
+    ) { triple, locations, notiPermissionState, elapsedLabel ->
         uiStateMapper.mapToUiState(
-            showInstructions = showInstructions,
-            status = status,
-            selected = selected,
+            showInstructions = triple.first,
+            status = triple.second,
+            selected = triple.third,
             locations = locations,
             hasNotificationPermission = notiPermissionState.isGranted,
+            elapsedLabel = elapsedLabel,
         )
     }.distinctUntilChanged().flowOn(Dispatchers.Default).stateIn(
         scope = viewModelScope,
@@ -104,6 +134,7 @@ class MockLocationViewModel(
         // after the user disables mocking.
         serviceStarter.stop()
         setMockLocationStatusUseCase.execute(false)
+        dataStore.edit { it[MOCK_STARTED_AT] = 0L }
     }
 
     private fun startMockLocation(location: MockLocation, service: IMockLocationService?) = viewModelScope.launch(Dispatchers.Default) {
@@ -120,5 +151,14 @@ class MockLocationViewModel(
         serviceStarter.start(location)
         service?.startMocking(location)
         setMockLocationStatusUseCase.execute(true)
+        dataStore.edit { it[MOCK_STARTED_AT] = System.currentTimeMillis() }
+    }
+
+    private fun formatElapsed(millis: Long): String {
+        val totalSeconds = millis / 1000
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val seconds = totalSeconds % 60
+        return "%02d:%02d:%02d".format(hours, minutes, seconds)
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
@@ -29,6 +29,8 @@ data class UiState(
     val status: Boolean,
     val hasNotificationPermission: Boolean,
     val items: List<UiItem>,
+    val elapsedLabel: String = "",
+    val selected: MockLocation? = null,
 ) {
     companion object {
         val Empty = UiState(
@@ -36,6 +38,8 @@ data class UiState(
             status = false,
             hasNotificationPermission = false,
             items = emptyList(),
+            elapsedLabel = "",
+            selected = null,
         )
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
@@ -10,6 +10,7 @@ object UiStateMapper {
         selected: MockLocation?,
         locations: List<MockLocation>,
         hasNotificationPermission: Boolean,
+        elapsedLabel: String,
     ): UiState {
         val items = buildList {
             add(SectionHeader.MockLocationStatus(isOn = status))
@@ -25,6 +26,32 @@ object UiStateMapper {
             status = status,
             hasNotificationPermission = hasNotificationPermission,
             items = items,
+            elapsedLabel = elapsedLabel,
+            selected = selected,
         )
     }
+
+    fun getCountryCode(locationName: String): String {
+        val country = locationName.substringAfter(',').trim()
+        return countryCodeMap[country] ?: "??"
+    }
+
+    private val countryCodeMap = mapOf(
+        "Singapore" to "SG",
+        "Sweden" to "SE",
+        "Türkiye" to "TR",
+        "Hong Kong" to "HK",
+        "Malaysia" to "MY",
+        "Norway" to "NO",
+        "Bangladesh" to "BD",
+        "Pakistan" to "PK",
+        "Philippines" to "PH",
+        "Taiwan" to "TW",
+        "Cambodia" to "KH",
+        "Laos" to "LA",
+        "Myanmar" to "MM",
+        "Czechia" to "CZ",
+        "Hungary" to "HU",
+        "Austria" to "AT",
+    )
 }

--- a/app/src/test/java/dev/randheer094/dev/location/domain/MockLocationTest.kt
+++ b/app/src/test/java/dev/randheer094/dev/location/domain/MockLocationTest.kt
@@ -100,4 +100,9 @@ class MockLocationTest {
 
         assertEquals(original, roundTripped)
     }
+
+    @Test
+    fun `MOCK_STARTED_AT preference key has the expected name`() {
+        assertEquals("mock_started_at", MOCK_STARTED_AT.name)
+    }
 }

--- a/app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt
+++ b/app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt
@@ -27,6 +27,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         assertFalse(state.showInstructions)
@@ -47,6 +48,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         val header = state.items.first() as SectionHeader.MockLocationStatus
@@ -62,6 +64,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         val header = state.items.first() as SectionHeader.MockLocationStatus
@@ -77,6 +80,7 @@ class UiStateMapperTest {
             selected = london,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         val selectedRow = state.items[1] as MockLocationNStatus
@@ -92,6 +96,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = false,
+            elapsedLabel = "",
         )
 
         val selectedRow = state.items[1] as MockLocationNStatus
@@ -107,6 +112,7 @@ class UiStateMapperTest {
             selected = null,
             locations = listOf(london, newYork),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         // [status header, MockLocationNStatus, SelectLocations, Location(london), Location(newYork)]
@@ -122,6 +128,7 @@ class UiStateMapperTest {
             selected = london,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         assertFalse(state.items.any { it === SectionHeader.SelectLocations })
@@ -137,6 +144,7 @@ class UiStateMapperTest {
             selected = null,
             locations = ordered,
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         val locationItems = state.items.filterIsInstance<Location>().map { it.location }
@@ -151,6 +159,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         assertTrue(state.showInstructions)
@@ -164,6 +173,7 @@ class UiStateMapperTest {
             selected = null,
             locations = emptyList(),
             hasNotificationPermission = false,
+            elapsedLabel = "",
         )
 
         assertFalse(state.hasNotificationPermission)
@@ -177,6 +187,7 @@ class UiStateMapperTest {
             selected = london,
             locations = listOf(newYork, tokyo),
             hasNotificationPermission = true,
+            elapsedLabel = "",
         )
 
         val items = state.items
@@ -198,5 +209,88 @@ class UiStateMapperTest {
         assertFalse(empty.status)
         assertFalse(empty.hasNotificationPermission)
         assertTrue(empty.items.isEmpty())
+    }
+
+    @Test
+    fun `elapsedLabel is passed through to UiState`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = true,
+            selected = null,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "01:23:45",
+        )
+
+        assertEquals("01:23:45", state.elapsedLabel)
+    }
+
+    @Test
+    fun `empty elapsedLabel is passed through to UiState`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+        )
+
+        assertEquals("", state.elapsedLabel)
+    }
+
+    @Test
+    fun `selected is passed through to UiState`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = true,
+            selected = london,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+        )
+
+        assertEquals(london, state.selected)
+    }
+
+    @Test
+    fun `null selected is passed through to UiState`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+        )
+
+        assertNull(state.selected)
+    }
+
+    @Test
+    fun `getCountryCode returns correct code for known countries`() {
+        assertEquals("SG", UiStateMapper.getCountryCode("Singapore, Singapore"))
+        assertEquals("SE", UiStateMapper.getCountryCode("Stockholm, Sweden"))
+        assertEquals("TR", UiStateMapper.getCountryCode("Istanbul, Türkiye"))
+        assertEquals("HK", UiStateMapper.getCountryCode("Kowloon, Hong Kong"))
+        assertEquals("MY", UiStateMapper.getCountryCode("Kuala Lumpur, Malaysia"))
+        assertEquals("NO", UiStateMapper.getCountryCode("Oslo, Norway"))
+        assertEquals("BD", UiStateMapper.getCountryCode("Dhaka, Bangladesh"))
+        assertEquals("PK", UiStateMapper.getCountryCode("Karachi, Pakistan"))
+        assertEquals("PH", UiStateMapper.getCountryCode("Manila, Philippines"))
+        assertEquals("TW", UiStateMapper.getCountryCode("Taipei, Taiwan"))
+        assertEquals("KH", UiStateMapper.getCountryCode("Phnom Penh, Cambodia"))
+        assertEquals("LA", UiStateMapper.getCountryCode("Vientiane, Laos"))
+        assertEquals("MM", UiStateMapper.getCountryCode("Yangon, Myanmar"))
+        assertEquals("CZ", UiStateMapper.getCountryCode("Prague, Czechia"))
+        assertEquals("HU", UiStateMapper.getCountryCode("Budapest, Hungary"))
+        assertEquals("AT", UiStateMapper.getCountryCode("Vienna, Austria"))
+    }
+
+    @Test
+    fun `getCountryCode returns fallback code for unknown country`() {
+        assertEquals("??", UiStateMapper.getCountryCode("Paris, France"))
+        assertEquals("??", UiStateMapper.getCountryCode("London, UK"))
+        assertEquals("??", UiStateMapper.getCountryCode("NoCommaHere"))
     }
 }


### PR DESCRIPTION
## Add elapsed timer and selected location to UiState

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt (modify)
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt (modify)
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt (modify)
- app/src/main/java/dev/randheer094/dev/location/domain/MockLocation.kt (modify)
- app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt (modify)
- app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt (modify)
- app/src/test/java/dev/randheer094/dev/location/domain/MockLocationTest.kt (modify)

Goal:
Expose an elapsedLabel string and selected MockLocation on UiState so the redesigned UI can display broadcasting duration and the active location, plus add a country-code derivation helper for the location list rows.

Acceptance criteria:
- UiState has new field: elapsedLabel: String (default "") containing formatted elapsed time "HH:MM:SS" when status is true, empty when false
- UiState has new field: selected: MockLocation? (default null) reflecting the currently selected/active location
- UiState.Empty updated with these new defaults
- New DataStore preference key in domain/MockLocation.kt: val MOCK_STARTED_AT = longPreferencesKey("mock_started_at") storing epoch millis when mocking starts; 0L when stopped
- In MockLocationViewModel.startMockLocation: after setMockLocationStatusUseCase.execute(true), write System.currentTimeMillis() to MOCK_STARTED_AT in DataStore
- In MockLocationViewModel.stopMockLocation: after setMockLocationStatusUseCase.execute(false), write 0L to MOCK_STARTED_AT in DataStore
- ViewModel adds a ticker flow: when MOCK_STARTED_AT > 0, emit formatted elapsed string every ~1 second; when 0, emit "". Use flow { while(true) { emit(Unit); delay(1000) } } combined with the DataStore key
- The existing combine() of 5 flows expands to 6 (adding the ticker) and passes elapsedLabel into UiStateMapper
- UiStateMapper.mapToUiState signature adds elapsedLabel: String and selected: MockLocation? parameters; populates the corresponding UiState fields
- UiStateMapper has a new function: fun getCountryCode(locationName: String): String that extracts the country from "City, Country" format (substringAfter(',').trim()) and returns a 2-letter ISO code from a static map. The 16 preset entries are: Singapore->SG, Sweden->SE, Türkiye->TR, Hong Kong->HK, Malaysia->MY, Norway->NO, Bangladesh->BD, Pakistan->PK, Philippines->PH, Taiwan->TW, Cambodia->KH, Laos->LA, Myanmar->MM, Czechia->CZ, Hungary->HU, Austria->AT. Unknown countries return "??"
- UiStateMapperTest has new tests: verifies elapsedLabel is passed through to UiState, verifies selected is passed through, verifies getCountryCode returns correct codes for known countries and "??" for unknown
- MockLocationTest updated if model or preference key changes require it
- The existing items list in UiState is unchanged — all current composables continue to work
- ./gradlew :app:testDebugUnitTest passes
- ./gradlew :app:compileDebugKotlin succeeds

Out of scope:
- Do not modify any theme files under presentation/theme/
- Do not modify any composable files under presentation/mocklocation/composable/
- Do not modify strings.xml or add icon files
- Do not modify MockLocationService or MockLocationServiceStarter
- Do not modify presentation/utils/ files

Context:
The ViewModel (MockLocationViewModel.kt) currently combines 5 flows via combine(): setupInstructionStatus, mockLocationStatus, selectedMockLocation, getMockLocations, notificationPermissionState. Add a 6th flow for the elapsed timer. The DataStore instance is already available — it's injected as a single in MockLocationModules.kt and used by the existing use cases. You can either inject the DataStore directly into the ViewModel (add it as a constructor parameter and register in MockLocationModules.kt) or create thin use cases (SaveMockStartTimeUseCase / GetMockStartTimeUseCase). Either approach is fine — match the existing conventions. The format function should produce "HH:MM:SS" using integer division of elapsed millis (e.g., hours = totalSeconds / 3600, minutes = (totalSeconds % 3600) / 60, seconds = totalSeconds % 60, each zero-padded to 2 digits). For the combine expansion: Kotlin's combine() supports up to 5 parameters natively — for 6+, use the array-based combine(flows: Iterable<Flow>) { ... } overload or nest two combine calls. The selected MockLocation is already available as the selectedMockLocationUseCase.execute() flow — just pass it through to UiState as a top-level field.

---

Jira: [ARC-149](https://randheercode.atlassian.net/browse/ARC-149)
