### PR TITLE
ARC-150: Add redesign string resources and custom icon vectors

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/ui/icons/MockIcons.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/ui/icons/MockIcons.kt
@@ -1,0 +1,40 @@
+package dev.randheer094.dev.location.presentation.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+object MockIcons {
+    val Pin: ImageVector by lazy {
+        ImageVector.Builder(
+            name = "Pin",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                pathFillType = PathFillType.EvenOdd
+            ) {
+                // Outer teardrop — round top, pointed bottom
+                moveTo(12f, 2f)
+                curveTo(8.13f, 2f, 5f, 5.13f, 5f, 9f)
+                curveTo(5f, 14.25f, 12f, 22f, 12f, 22f)
+                curveTo(12f, 22f, 19f, 14.25f, 19f, 9f)
+                curveTo(19f, 5.13f, 15.87f, 2f, 12f, 2f)
+                close()
+                // Inner circle cutout
+                moveTo(14.5f, 9f)
+                curveTo(14.5f, 7.62f, 13.38f, 6.5f, 12f, 6.5f)
+                curveTo(10.62f, 6.5f, 9.5f, 7.62f, 9.5f, 9f)
+                curveTo(9.5f, 10.38f, 10.62f, 11.5f, 12f, 11.5f)
+                curveTo(13.38f, 11.5f, 14.5f, 10.38f, 14.5f, 9f)
+                close()
+            }
+        }.build()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,51 @@
     <string name="cd_edit_location">Edit location</string>
     <string name="cd_start_mocking">Start mocking</string>
     <string name="cd_stop_mocking">Stop mocking</string>
+
+    <!-- Home screen -->
+    <string name="wordmark_mock">mock</string>
+    <string name="wordmark_location">location</string>
+    <string name="status_live">LIVE · GPS + NET</string>
+    <string name="status_mock_off">Mock location off</string>
+    <string name="status_ready">Ready</string>
+    <string name="overline_currently_spoofing">CURRENTLY SPOOFING</string>
+    <string name="section_preset_locations">PRESET LOCATIONS</string>
+    <string name="label_sort_az">Sort · A–Z</string>
+    <string name="btn_stop_broadcasting">Stop broadcasting</string>
+    <string name="badge_live">LIVE</string>
+    <string name="overline_last_used">LAST USED</string>
+    <string name="btn_start">Start</string>
+    <string name="timer_format">T+ %1$s</string>
+
+    <!-- Bottom sheet -->
+    <string name="sheet_title_custom_location">Custom location</string>
+    <string name="sheet_subtitle">Enter a label and coordinates. Saved to your library.</string>
+    <string name="overline_name">NAME</string>
+    <string name="helper_name">A friendly label for your library.</string>
+    <string name="overline_latitude">LATITUDE</string>
+    <string name="overline_longitude">LONGITUDE</string>
+    <string name="helper_latitude">−90 to 90</string>
+    <string name="helper_longitude">−180 to 180</string>
+    <string name="validation_valid">Valid coordinates · Closest city: %1$s</string>
+    <string name="validation_lat_out_of_range">Latitude out of range</string>
+    <string name="validation_lng_out_of_range">Longitude out of range</string>
+    <string name="btn_set_mock_location_new">Set mock location</string>
+    <string name="tip_paste">Tip: paste 37.7749, −122.4194 into any field</string>
+    <string name="snackbar_added">Added \"%1$s\" to your library</string>
+
+    <!-- Setup screen -->
+    <string name="setup_step_label">Setup · step %1$d of %2$d</string>
+    <string name="overline_one_time_setup">ONE-TIME SETUP</string>
+    <string name="setup_headline_line1">Let Android know</string>
+    <string name="setup_headline_line2">we’re the boss of GPS.</string>
+    <string name="setup_supporting_text">Android requires you to manually authorize a mock-location provider. Takes about 20 seconds.</string>
+    <string name="step1_title">Open Developer Options</string>
+    <string name="step1_body">On your device, go to Settings → System → Developer options.</string>
+    <string name="step1_code">adb shell am start -a android.settings.APPLICATION_DEVELOPMENT_SETTINGS</string>
+    <string name="step2_title">Find \"Select mock location app\"</string>
+    <string name="step2_body">Scroll to the Debugging section. Tap the row.</string>
+    <string name="step3_title">Pick Mock Location</string>
+    <string name="step3_body">Select this app from the list. You’ll see it appear in your debug surface.</string>
+    <string name="btn_open_dev_options">Open developer options</string>
+    <string name="btn_check_again">I’ve done this — check again</string>
 </resources>


### PR DESCRIPTION
## Add redesign string resources and custom icon vectors

Files to change:
- app/src/main/res/values/strings.xml (modify)
- app/src/main/java/dev/randheer094/dev/location/presentation/ui/icons/MockIcons.kt (create)

Goal:
Pre-populate all new string resources and custom ImageVector icons needed by the redesigned screens so downstream composable tasks can reference them without touching these files.

Acceptance criteria:
- All existing string resources in strings.xml are preserved (not removed or renamed)
- The following new string resources are added to strings.xml (use snake_case names, group by screen with XML comments):
- Home screen strings: wordmark_mock="mock", wordmark_location="location", status_live="LIVE \u00B7 GPS + NET", status_mock_off="Mock location off", status_ready="Ready", overline_currently_spoofing="CURRENTLY SPOOFING", section_preset_locations="PRESET LOCATIONS", label_sort_az="Sort \u00B7 A\u2013Z", btn_stop_broadcasting="Stop broadcasting", badge_live="LIVE", overline_last_used="LAST USED", btn_start="Start", timer_format="T+ %1$s"
- Bottom sheet strings: sheet_title_custom_location="Custom location", sheet_subtitle="Enter a label and coordinates. Saved to your library.", overline_name="NAME", helper_name="A friendly label for your library.", overline_latitude="LATITUDE", overline_longitude="LONGITUDE", helper_latitude="\u221290 to 90", helper_longitude="\u2212180 to 180", validation_valid="Valid coordinates \u00B7 Closest city: %1$s", validation_lat_out_of_range="Latitude out of range", validation_lng_out_of_range="Longitude out of range", btn_set_mock_location_new="Set mock location", tip_paste="Tip: paste 37.7749, \u2212122.4194 into any field", snackbar_added="Added \"%1$s\" to your library"
- Setup screen strings: setup_step_label="Setup \u00B7 step %1$d of %2$d", overline_one_time_setup="ONE-TIME SETUP", setup_headline_line1="Let Android know", setup_headline_line2="we\u2019re the boss of GPS.", setup_supporting_text="Android requires you to manually authorize a mock-location provider. Takes about 20 seconds.", step1_title="Open Developer Options", step1_body="On your device, go to Settings \u2192 System \u2192 Developer options.", step1_code="adb shell am start -a android.settings.APPLICATION_DEVELOPMENT_SETTINGS", step2_title="Find \"Select mock location app\"", step2_body="Scroll to the Debugging section. Tap the row.", step3_title="Pick Mock Location", step3_body="Select this app from the list. You\u2019ll see it appear in your debug surface.", btn_open_dev_options="Open developer options", btn_check_again="I\u2019ve done this \u2014 check again"
- MockIcons.kt is created at package dev.randheer094.dev.location.presentation.ui.icons
- MockIcons is an object containing a Pin ImageVector property (lazy-initialized): a 24dp viewport teardrop/pin shape with an inner circle cutout, single-color, similar to Material LocationOn but simplified to a filled teardrop with a small inner dot
- ./gradlew :app:compileDebugKotlin succeeds

Out of scope:
- Do not modify any theme files under presentation/theme/
- Do not modify any composable files under presentation/mocklocation/
- Do not modify state, ViewModel, domain, DI, or service files
- Do not add or modify font files

Context:
The redesigned UI introduces substantial new copy across three screens. All user-visible text must use stringResource() per the project rule in .claude/rules.md (rule 20: "UI strings live in res/values/strings.xml. Do not inline user-visible text in composables."). By pre-populating these strings in this task, the composable rewrite tasks in the next wave can reference them directly via R.string.* without merge conflicts on strings.xml. Unicode escapes: \u00B7 is middle dot (·), \u2013 is en-dash (–), \u2212 is minus sign (−), \u2192 is right arrow (→), \u2019 is right single quote ('). For the MockIcons.Pin vector: use ImageVector.Builder with a 24x24 viewport. Draw a teardrop path (moveTo the top center, arc down and around to form the pointed bottom, close). Add a small inner circle via addPath. Keep it simple — this icon appears at 18-30dp in the wordmark and CTA buttons. Define it in a companion-like structure: object MockIcons { val Pin: ImageVector by lazy { ImageVector.Builder(...).build() } }.

---

Jira: [ARC-150](https://randheercode.atlassian.net/browse/ARC-150)
