### PR TITLE
ARC-152: Redesign setup instructions screen with step cards

### DIFF
--- a/app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstructionTest.kt
+++ b/app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstructionTest.kt
@@ -15,23 +15,34 @@ class SetupInstructionTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun shows_title_body_and_dismiss_button() {
+    fun shows_all_three_step_card_titles() {
         composeRule.setContent {
             MockLocationTheme { SetupInstruction(onGotIt = {}) }
         }
 
-        composeRule.onNodeWithText("Setup Instructions").assertIsDisplayed()
-        composeRule.onNodeWithText("Got it!").assertIsDisplayed()
+        composeRule.onNodeWithText("Open Developer Options").assertIsDisplayed()
+        composeRule.onNodeWithText(“Find \”Select mock location app\””).assertIsDisplayed()
+        composeRule.onNodeWithText("Pick Mock Location").assertIsDisplayed()
     }
 
     @Test
-    fun got_it_click_invokes_callback_exactly_once() {
+    fun primary_cta_is_displayed_and_clickable() {
+        composeRule.setContent {
+            MockLocationTheme { SetupInstruction(onGotIt = {}) }
+        }
+
+        composeRule.onNodeWithText("Open developer options").assertIsDisplayed()
+        composeRule.onNodeWithText("Open developer options").performClick()
+    }
+
+    @Test
+    fun secondary_cta_triggers_on_got_it_callback() {
         var clicks = 0
         composeRule.setContent {
             MockLocationTheme { SetupInstruction(onGotIt = { clicks++ }) }
         }
 
-        composeRule.onNodeWithText("Got it!").performClick()
+        composeRule.onNodeWithText("I’ve done this — check again").performClick()
         assertEquals(1, clicks)
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
@@ -1,86 +1,384 @@
 package dev.randheer094.dev.location.presentation.mocklocation.composable
 
+import android.app.Activity
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowOutward
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.randheer094.dev.location.R
+import dev.randheer094.dev.location.presentation.theme.InterFamily
+import dev.randheer094.dev.location.presentation.theme.JetBrainsMonoFamily
+import dev.randheer094.dev.location.presentation.theme.LocalMockColors
+import dev.randheer094.dev.location.presentation.theme.MockColors
+import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
 
 @Composable
 fun SetupInstruction(onGotIt: () -> Unit) {
+    val colors = LocalMockColors.current
+    val context = LocalContext.current
+
     Scaffold(
-        containerColor = MaterialTheme.colorScheme.surface,
-    ) { innerPadding ->
+        containerColor = colors.bg,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+    ) { _ ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .verticalScroll(rememberScrollState()),
         ) {
-            Surface(
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(96.dp),
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(contentAlignment = Alignment.Center) {
+                IconButton(
+                    onClick = onGotIt,
+                    modifier = Modifier.size(40.dp),
+                ) {
                     Icon(
-                        imageVector = Icons.Default.Settings,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = null,
-                        modifier = Modifier.size(48.dp),
+                        tint = colors.text,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.setup_step_label, 1, 3),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = colors.textDim,
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.size(40.dp))
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(top = 24.dp),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(100.dp),
+                    color = colors.accentSoft,
+                    border = BorderStroke(1.dp, colors.accentGhost),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(
+                            start = 9.dp, top = 6.dp, end = 11.dp, bottom = 6.dp,
+                        ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = null,
+                            tint = colors.accent,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Text(
+                            text = stringResource(R.string.overline_one_time_setup),
+                            style = TextStyle(
+                                fontFamily = InterFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 11.sp,
+                                letterSpacing = 1.6.sp,
+                            ),
+                            color = colors.accent,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.setup_headline_line1),
+                    style = TextStyle(
+                        fontFamily = InterFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 34.sp,
+                        lineHeight = (34 * 1.04).sp,
+                        letterSpacing = (-1.2).sp,
+                    ),
+                    color = colors.text,
+                )
+                Text(
+                    text = stringResource(R.string.setup_headline_line2),
+                    style = TextStyle(
+                        fontFamily = InterFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 34.sp,
+                        lineHeight = (34 * 1.04).sp,
+                        letterSpacing = (-1.2).sp,
+                    ),
+                    color = colors.textDim,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = stringResource(R.string.setup_supporting_text),
+                    style = TextStyle(
+                        fontFamily = InterFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp,
+                        lineHeight = (14 * 1.5).sp,
+                    ),
+                    color = colors.textDim,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                StepCard(
+                    number = "01",
+                    title = stringResource(R.string.step1_title),
+                    body = stringResource(R.string.step1_body),
+                    isAccent = true,
+                    codeBlock = stringResource(R.string.step1_code),
+                    colors = colors,
+                )
+                StepCard(
+                    number = "02",
+                    title = stringResource(R.string.step2_title),
+                    body = stringResource(R.string.step2_body),
+                    isAccent = false,
+                    codeBlock = null,
+                    colors = colors,
+                )
+                StepCard(
+                    number = "03",
+                    title = stringResource(R.string.step3_title),
+                    body = stringResource(R.string.step3_body),
+                    isAccent = false,
+                    codeBlock = null,
+                    colors = colors,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Button(
+                    onClick = {
+                        (context as? Activity)?.startActivity(
+                            Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS),
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(54.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.accent,
+                        contentColor = colors.accentInk,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.btn_open_dev_options),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Icon(
+                        imageVector = Icons.Filled.ArrowOutward,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+
+                OutlinedButton(
+                    onClick = onGotIt,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    border = BorderStroke(1.dp, colors.border),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = colors.textDim,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.btn_check_again),
+                        style = MaterialTheme.typography.labelLarge,
                     )
                 }
             }
 
-            Text(
-                text = stringResource(R.string.setup_instructions_title),
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                textAlign = TextAlign.Center,
-            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
 
-            Text(
-                text = stringResource(R.string.setup_instructions_body),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Start,
-            )
+@Composable
+private fun StepCard(
+    number: String,
+    title: String,
+    body: String,
+    isAccent: Boolean,
+    codeBlock: String?,
+    colors: MockColors,
+) {
+    val codeBlockBg = colors.chipBg
+    val borderStrong = colors.borderStrong
 
-            Button(
-                onClick = onGotIt,
-                modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.large,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ),
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = colors.card,
+        border = BorderStroke(1.dp, colors.border),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = if (isAccent) colors.accent else colors.chipBg,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        text = number,
+                        style = TextStyle(
+                            fontFamily = JetBrainsMonoFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp,
+                        ),
+                        color = if (isAccent) colors.accentInk else colors.textDim,
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = stringResource(R.string.setup_instructions_got_it),
-                    style = MaterialTheme.typography.labelLarge,
+                    text = title,
+                    style = TextStyle(
+                        fontFamily = InterFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        letterSpacing = (-0.2).sp,
+                    ),
+                    color = colors.text,
                 )
+                Text(
+                    text = body,
+                    style = TextStyle(
+                        fontFamily = InterFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 13.sp,
+                        lineHeight = (13 * 1.5).sp,
+                    ),
+                    color = colors.textDim,
+                )
+                if (codeBlock != null) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .drawBehind {
+                                drawRoundRect(
+                                    color = codeBlockBg,
+                                    cornerRadius = CornerRadius(8.dp.toPx()),
+                                )
+                                drawRoundRect(
+                                    color = borderStrong,
+                                    style = Stroke(
+                                        width = 1.dp.toPx(),
+                                        pathEffect = PathEffect.dashPathEffect(
+                                            floatArrayOf(4f, 4f),
+                                        ),
+                                    ),
+                                    cornerRadius = CornerRadius(8.dp.toPx()),
+                                )
+                            }
+                            .padding(10.dp),
+                    ) {
+                        Text(
+                            text = codeBlock,
+                            style = TextStyle(
+                                fontFamily = JetBrainsMonoFamily,
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 11.sp,
+                            ),
+                            color = colors.textDim,
+                        )
+                    }
+                }
             }
         }
+    }
+}
+
+@Preview(name = "Light")
+@Composable
+private fun SetupInstructionLightPreview() {
+    MockLocationTheme(darkTheme = false) {
+        SetupInstruction(onGotIt = {})
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun SetupInstructionDarkPreview() {
+    MockLocationTheme(darkTheme = true) {
+        SetupInstruction(onGotIt = {})
     }
 }


### PR DESCRIPTION
## Redesign setup instructions screen with step cards

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt (rewrite)
- app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstructionTest.kt (rewrite)

Goal:
Rewrite the setup instructions composable to a multi-step card layout with branded hero section, three numbered step cards, and two CTA buttons — while maintaining the same external function signature so the call site does not need modification.

Acceptance criteria:
- Composable function signature remains: fun SetupInstruction(onGotIt: () -> Unit) — do NOT rename or add parameters. The parent screen calls this by name with a single callback
- Overall layout: Column inside a Scaffold (or Box) with bg background color, statusBarsPadding at top, navigationBarsPadding at bottom
- Top bar (Row, 16dp horizontal padding): 40dp IconButton on left with Icons.AutoMirrored.Filled.ArrowBack triggering onGotIt, centered Text "Setup · step 1 of 3" (labelLarge, textDim) using stringResource(R.string.setup_step_label, 1, 3), 40dp Spacer on right for balance
- Hero section (20dp horizontal padding, 24dp top): overline pill Surface (RoundedCornerShape(100.dp), accentSoft fill, 1dp accentGhost border, 9dp/6dp/11dp/6dp padding) containing Icons.Outlined.Info (14dp, accent) + "ONE-TIME SETUP" text (11sp/700/1.6sp, accent, uppercase). Display headline: first line "Let Android know" (34sp/700/-1.2sp/1.04 line height, text color), second line "we're the boss of GPS." (same style, textDim color). Supporting body text below (14sp/500, textDim, 1.5 line height)
- Three step cards (Column, Arrangement.spacedBy(10.dp), 16dp horizontal padding, 20dp top): each card is a Surface with RoundedCornerShape(18.dp), card fill, 1dp border, 14dp internal padding. Leading 32x32dp number tile with RoundedCornerShape(10.dp): step 1 has accent fill + accentInk text, steps 2-3 have chipBg fill + textDim text. Number text in JetBrains Mono 14sp/700 ("01", "02", "03"). Title: 15sp/600/-0.2sp, text color. Body: 13sp/500, textDim, 1.5 line height
- Step 1 ("Open Developer Options"): body text + code block below. Code block: Surface with RoundedCornerShape(8.dp), faint fill (chipBg), dashed border drawn via Modifier.drawBehind { drawRoundRect(color = borderStrong, style = Stroke(width = 1.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f))), cornerRadius = CornerRadius(8.dp.toPx())) }. Code text in JetBrains Mono 11sp/500, textDim
- Step 2 ("Find \"Select mock location app\""): title + body text only
- Step 3 ("Pick Mock Location"): title + body text only
- All step titles and bodies use stringResource() references to the strings added in Wave 1
- CTA cluster (16dp horizontal padding, 18dp top): primary Button 54dp height, RoundedCornerShape(16.dp), accent fill, accentInk content, label "Open developer options" + Icons.Filled.ArrowOutward icon. Tapping launches Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS via (LocalContext.current as Activity).startActivity(Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)). Secondary OutlinedButton 48dp height, RoundedCornerShape(14.dp), label "I've done this — check again", triggers onGotIt callback
- All colors from LocalMockColors.current, typography from MaterialTheme.typography
- @Preview annotations for light + dark mode
- Instrumentation test (SetupInstructionTest.kt) rewrites: verify three step cards are rendered (assert text for each step title), verify primary CTA button is displayed and clickable, verify secondary CTA triggers the onGotIt callback
- ./gradlew :app:compileDebugKotlin succeeds

Out of scope:
- Do not modify MockLocationScreen.kt or any other composable file
- Do not modify MockLocationViewModel.kt, UiState, or domain classes
- Do not modify theme files, strings.xml, or icons

Context:
Refer to design_requirement/README.md section "4. Setup instructions — First run" for complete layout spec and copy.

The current SetupInstruction (SetupInstruction.kt) is a simple full-screen overlay with an icon, title, body, and single "Got it!" button. It receives onGotIt: () -> Unit which MockLocationScreen maps to viewModel.onInstructionDismiss(). The rewrite transforms it into a rich multi-step layout but the external contract stays identical: one callback that means "user is done with setup." The primary CTA ("Open developer options") launches the Android Settings activity — do this internally via LocalContext without needing a new callback. The secondary CTA ("I've done this — check again") maps to the existing onGotIt callback. When the user returns from Settings and the app resumes, the existing flow in MockLocationScreen re-evaluates uiState.showInstructions — if the mock location provider is now set, the instructions screen disappears automatically.

For the JetBrains Mono font in the code block and number tiles: import the MonoStyle or JetBrainsMonoFamily from the theme Typography file (it was added in the Wave 1 theme task as a public val in Typography.kt).

Note on the dashed border: Compose has no built-in dashed-border modifier. Use Modifier.drawBehind with a Stroke that has a PathEffect.dashPathEffect. The float array [4f, 4f] creates a 4px dash + 4px gap pattern.

---

Jira: [ARC-152](https://randheercode.atlassian.net/browse/ARC-152)
