### PR TITLE
ARC-153: Redesign custom coordinates bottom sheet

### DIFF
--- a/app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheetTest.kt
+++ b/app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheetTest.kt
@@ -1,7 +1,10 @@
 package dev.randheer094.dev.location.presentation.mocklocation.composable
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -9,103 +12,81 @@ import dev.randheer094.dev.location.domain.MockLocation
 import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
-/**
- * Compose UI tests for [AddMockLocationBottomSheet]. Covers the validation rules that live in
- * the composable itself: coordinates must parse as doubles within geographic bounds, and the
- * display name is prefixed with "(Manual)" before being emitted.
- */
 class AddMockLocationBottomSheetTest {
 
     @get:Rule
     val composeRule = createComposeRule()
 
     @Test
-    fun valid_coordinates_are_emitted_with_manual_prefix_on_submit() {
+    fun fields_render_and_accept_input() {
+        composeRule.setContent {
+            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = {}) }
+        }
+
+        composeRule.onNodeWithTag("name_field").assertIsDisplayed()
+        composeRule.onNodeWithTag("lat_field").assertIsDisplayed()
+        composeRule.onNodeWithTag("lng_field").assertIsDisplayed()
+
+        composeRule.onNodeWithTag("name_field").performTextInput("Home")
+        composeRule.onNodeWithTag("lat_field").performTextInput("12.9716")
+        composeRule.onNodeWithTag("lng_field").performTextInput("77.5946")
+    }
+
+    @Test
+    fun validation_strip_shows_error_for_out_of_range_latitude() {
+        composeRule.setContent {
+            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = {}) }
+        }
+
+        composeRule.onNodeWithTag("lat_field").performTextInput("100")
+
+        composeRule.onNodeWithText("Latitude out of range").assertIsDisplayed()
+    }
+
+    @Test
+    fun cta_button_is_disabled_when_fields_are_empty() {
+        composeRule.setContent {
+            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = {}) }
+        }
+
+        composeRule.onNodeWithTag("cta_button").assertIsNotEnabled()
+    }
+
+    @Test
+    fun cta_button_is_enabled_when_valid_coordinates_entered() {
+        composeRule.setContent {
+            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = {}) }
+        }
+
+        composeRule.onNodeWithTag("lat_field").performTextInput("37.7749")
+        composeRule.onNodeWithTag("lng_field").performTextInput("-122.4194")
+
+        composeRule.onNodeWithTag("cta_button").assertIsEnabled()
+    }
+
+    @Test
+    fun onsubmit_fires_with_correct_mock_location_on_button_click() {
         var submitted: MockLocation? = null
         composeRule.setContent {
             MockLocationTheme { AddMockLocationBottomSheet(onSubmit = { submitted = it }) }
         }
 
-        composeRule.onNodeWithText("Name").performTextInput("Home")
-        composeRule.onNodeWithText("Latitude").performTextInput("12.9716")
-        composeRule.onNodeWithText("Longitude").performTextInput("77.5946")
+        composeRule.onNodeWithTag("name_field").performTextInput("Home")
+        composeRule.onNodeWithTag("lat_field").performTextInput("12.9716")
+        composeRule.onNodeWithTag("lng_field").performTextInput("77.5946")
 
-        composeRule.onNodeWithText("Set Mock Location").performClick()
+        composeRule.onNodeWithTag("cta_button").performClick()
 
         assertNotNull("Submit callback should fire for valid input", submitted)
-        assertEquals(12.9716, submitted!!.lat, 0.0)
-        assertEquals(77.5946, submitted!!.long, 0.0)
+        assertEquals(12.9716, submitted!!.lat, 1e-10)
+        assertEquals(77.5946, submitted!!.long, 1e-10)
         assertTrue(
-            "Name should be wrapped with the (Manual) prefix, was: ${submitted!!.name}",
+            "Name should be wrapped with (Manual) prefix and contain the label, was: ${submitted!!.name}",
             submitted!!.name.startsWith("(Manual)") && submitted!!.name.contains("Home"),
         )
-    }
-
-    @Test
-    fun blank_name_falls_back_to_coordinate_pair_as_display_name() {
-        var submitted: MockLocation? = null
-        composeRule.setContent {
-            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = { submitted = it }) }
-        }
-
-        composeRule.onNodeWithText("Latitude").performTextInput("48.8566")
-        composeRule.onNodeWithText("Longitude").performTextInput("2.3522")
-        composeRule.onNodeWithText("Set Mock Location").performClick()
-
-        assertNotNull(submitted)
-        assertTrue(
-            "Name should fall back to lat, long, was: ${submitted!!.name}",
-            submitted!!.name.contains("48.8566") && submitted!!.name.contains("2.3522"),
-        )
-    }
-
-    @Test
-    fun out_of_range_latitude_surfaces_validation_error_and_suppresses_submit() {
-        var submitted: MockLocation? = null
-        composeRule.setContent {
-            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = { submitted = it }) }
-        }
-
-        composeRule.onNodeWithText("Latitude").performTextInput("100")
-        composeRule.onNodeWithText("Longitude").performTextInput("2.0")
-        composeRule.onNodeWithText("Set Mock Location").performClick()
-
-        composeRule.onNodeWithText("Invalid latitude or longitude").assertIsDisplayed()
-        assertNull(submitted)
-    }
-
-    @Test
-    fun out_of_range_longitude_is_rejected() {
-        var submitted: MockLocation? = null
-        composeRule.setContent {
-            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = { submitted = it }) }
-        }
-
-        composeRule.onNodeWithText("Latitude").performTextInput("20.0")
-        composeRule.onNodeWithText("Longitude").performTextInput("-190")
-        composeRule.onNodeWithText("Set Mock Location").performClick()
-
-        composeRule.onNodeWithText("Invalid latitude or longitude").assertIsDisplayed()
-        assertNull(submitted)
-    }
-
-    @Test
-    fun non_numeric_input_is_rejected() {
-        var submitted: MockLocation? = null
-        composeRule.setContent {
-            MockLocationTheme { AddMockLocationBottomSheet(onSubmit = { submitted = it }) }
-        }
-
-        composeRule.onNodeWithText("Latitude").performTextInput("abc")
-        composeRule.onNodeWithText("Longitude").performTextInput("xyz")
-        composeRule.onNodeWithText("Set Mock Location").performClick()
-
-        composeRule.onNodeWithText("Invalid latitude or longitude").assertIsDisplayed()
-        assertNull(submitted)
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
@@ -1,151 +1,408 @@
 package dev.randheer094.dev.location.presentation.mocklocation.composable
 
+import android.content.res.Configuration
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.randheer094.dev.location.R
 import dev.randheer094.dev.location.domain.MockLocation
+import dev.randheer094.dev.location.presentation.theme.JetBrainsMonoFamily
+import dev.randheer094.dev.location.presentation.theme.LocalMockColors
+import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
+import dev.randheer094.dev.location.presentation.ui.icons.MockIcons
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+private data class PresetCity(val name: String, val lat: Double, val lng: Double)
+
+private val PRESET_CITIES = listOf(
+    PresetCity("Singapore", 1.2806319, 103.8501362),
+    PresetCity("Stockholm", 59.3383223, 18.0549621),
+    PresetCity("Istanbul", 41.0763745, 29.0114464),
+    PresetCity("Hong Kong", 22.2848692, 114.1410492),
+    PresetCity("Kuala Lumpur", 3.1115726, 101.6633107),
+    PresetCity("Oslo", 59.9271583, 10.7246093),
+    PresetCity("Dhaka", 23.8516649, 90.2535154),
+    PresetCity("Karachi", 24.8653886, 67.0535651),
+    PresetCity("Manila", 14.5574546, 120.9863673),
+    PresetCity("Taipei", 25.0415595, 121.5630013),
+    PresetCity("Cambodia", 11.5526867, 104.9374995),
+    PresetCity("Laos", 17.9772614, 102.6132033),
+    PresetCity("Myanmar", 16.8422397, 96.1543628),
+    PresetCity("Prague", 50.1039621, 14.528223),
+    PresetCity("Budapest", 47.4752135, 19.0691096),
+    PresetCity("Vienna", 48.1972505, 16.3857097),
+)
+
+private fun closestCityName(lat: Double, lng: Double): String {
+    return PRESET_CITIES.minByOrNull { city ->
+        val dLat = Math.toRadians(city.lat - lat)
+        val dLng = Math.toRadians(city.lng - lng)
+        val a = sin(dLat / 2).pow(2) +
+                cos(Math.toRadians(lat)) * cos(Math.toRadians(city.lat)) * sin(dLng / 2).pow(2)
+        atan2(sqrt(a), sqrt(1 - a))
+    }?.name ?: PRESET_CITIES[0].name
+}
 
 @Composable
 fun AddMockLocationBottomSheet(
     modifier: Modifier = Modifier,
     onSubmit: (location: MockLocation) -> Unit,
 ) {
+    val colors = LocalMockColors.current
     var name by remember { mutableStateOf("") }
     var latitude by remember { mutableStateOf("") }
     var longitude by remember { mutableStateOf("") }
-    var error by remember { mutableStateOf<String?>(null) }
 
-    val errorMessage = stringResource(R.string.error_invalid_lat_long)
     val manualPrefixTemplate = stringResource(R.string.manual_location_prefix)
+
+    val latDouble = latitude.toDoubleOrNull()
+    val lngDouble = longitude.toDoubleOrNull()
+    val latValid = latDouble != null && latDouble in -90.0..90.0
+    val lngValid = lngDouble != null && lngDouble in -180.0..180.0
+    val isValid = latValid && lngValid
+
+    val showStrip = latitude.isNotBlank() || longitude.isNotBlank()
+
+    val latOutOfRangeMsg = stringResource(R.string.validation_lat_out_of_range)
+    val lngOutOfRangeMsg = stringResource(R.string.validation_lng_out_of_range)
+    val invalidCoordMsg = stringResource(R.string.error_invalid_lat_long)
+
+    val errorMsg: String? = when {
+        !showStrip || isValid -> null
+        latDouble != null && latDouble !in -90.0..90.0 -> latOutOfRangeMsg
+        latitude.isNotBlank() && latDouble == null -> invalidCoordMsg
+        lngDouble != null && lngDouble !in -180.0..180.0 -> lngOutOfRangeMsg
+        longitude.isNotBlank() && lngDouble == null -> invalidCoordMsg
+        else -> null
+    }
+
+    val closestCity = if (isValid) closestCityName(latDouble!!, lngDouble!!) else ""
+    val validMsg = stringResource(R.string.validation_valid, closestCity)
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        unfocusedContainerColor = colors.chipBg,
+        focusedContainerColor = colors.chipBg,
+        unfocusedBorderColor = colors.borderStrong,
+        focusedBorderColor = colors.accent,
+        unfocusedTextColor = colors.text,
+        focusedTextColor = colors.text,
+        unfocusedSupportingTextColor = colors.textMute,
+        focusedSupportingTextColor = colors.textMute,
+        unfocusedLabelColor = colors.textDim,
+        focusedLabelColor = colors.accent,
+    )
 
     Column(
         modifier = modifier
-            .padding(horizontal = 24.dp)
-            .padding(bottom = 24.dp)
-            .navigationBarsPadding(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            .padding(horizontal = 20.dp)
+            .padding(top = 10.dp)
+            .navigationBarsPadding()
+            .padding(bottom = 28.dp),
     ) {
-        Text(
-            text = stringResource(R.string.add_mock_location_title),
-            style = MaterialTheme.typography.headlineSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        // Title row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.sheet_title_custom_location),
+                style = MaterialTheme.typography.titleLarge,
+                color = colors.text,
+            )
+            IconButton(
+                onClick = {},
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = null,
+                    tint = colors.textDim,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
 
         Text(
-            text = stringResource(R.string.add_mock_location_subtitle),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            text = stringResource(R.string.sheet_subtitle),
+            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Medium),
+            color = colors.textDim,
         )
 
+        Spacer(Modifier.height(16.dp))
+
+        // Name field with overline label
+        Text(
+            text = stringResource(R.string.overline_name),
+            style = MaterialTheme.typography.labelSmall,
+            color = colors.textDim,
+        )
+        Spacer(Modifier.height(4.dp))
         OutlinedTextField(
             value = name,
             onValueChange = { name = it },
-            label = { Text(stringResource(R.string.label_name)) },
             singleLine = true,
-            shape = MaterialTheme.shapes.medium,
+            shape = RoundedCornerShape(14.dp),
+            colors = fieldColors,
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Next
+                imeAction = ImeAction.Next,
             ),
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        OutlinedTextField(
-            value = latitude,
-            onValueChange = {
-                latitude = it
-                if (error != null) error = null
-            },
-            label = { Text(stringResource(R.string.label_latitude)) },
-            singleLine = true,
-            shape = MaterialTheme.shapes.medium,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Next
-            ),
-            modifier = Modifier.fillMaxWidth(),
-            isError = error != null,
-            supportingText = if (error != null) {
-                { Text(text = error!!) }
-            } else {
-                null
-            },
-        )
-
-        OutlinedTextField(
-            value = longitude,
-            onValueChange = {
-                longitude = it
-                if (error != null) error = null
-            },
-            label = { Text(stringResource(R.string.label_longitude)) },
-            singleLine = true,
-            shape = MaterialTheme.shapes.medium,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Done
-            ),
-            modifier = Modifier.fillMaxWidth(),
-            isError = error != null,
-        )
-
-        Button(
-            onClick = {
-                val lat = latitude.toDoubleOrNull()
-                val long = longitude.toDoubleOrNull()
-
-                if (lat == null || long == null || lat !in -90.0..90.0 || long !in -180.0..180.0) {
-                    error = errorMessage
-                    return@Button
-                }
-
-                error = null
-                val displayName = manualPrefixTemplate.format(name.ifBlank { "${lat}, ${long}" })
-                onSubmit(
-                    MockLocation(
-                        name = displayName,
-                        lat = lat,
-                        long = long,
-                    )
+            supportingText = {
+                Text(
+                    text = stringResource(R.string.helper_name),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.textMute,
                 )
             },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("name_field"),
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        // Latitude / Longitude side-by-side row
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.large,
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-            ),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Icon(imageVector = Icons.Default.Check, contentDescription = null)
-            Spacer(Modifier.size(8.dp))
-            Text(
-                text = stringResource(R.string.cta_set_mock_location),
-                style = MaterialTheme.typography.labelLarge,
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.overline_latitude),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.textDim,
+                )
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = latitude,
+                    onValueChange = { newVal ->
+                        if (newVal.contains(",")) {
+                            val parts = newVal.split(",")
+                            latitude = parts[0].trim()
+                            longitude = parts.getOrElse(1) { "" }.trim()
+                        } else {
+                            latitude = newVal
+                        }
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(14.dp),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = JetBrainsMonoFamily),
+                    colors = fieldColors,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next,
+                    ),
+                    supportingText = {
+                        Text(
+                            text = stringResource(R.string.helper_latitude),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.textMute,
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("lat_field"),
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.overline_longitude),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.textDim,
+                )
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = longitude,
+                    onValueChange = { newVal ->
+                        if (newVal.contains(",")) {
+                            val parts = newVal.split(",")
+                            latitude = parts[0].trim()
+                            longitude = parts.getOrElse(1) { "" }.trim()
+                        } else {
+                            longitude = newVal
+                        }
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(14.dp),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = JetBrainsMonoFamily),
+                    colors = fieldColors,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Done,
+                    ),
+                    supportingText = {
+                        Text(
+                            text = stringResource(R.string.helper_longitude),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.textMute,
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("lng_field"),
+                )
+            }
         }
+
+        // Validation strip (12dp top spacing, shown when at least one coord field has content)
+        Spacer(Modifier.height(12.dp))
+        if (showStrip && (isValid || errorMsg != null)) {
+            val stripBg = if (isValid) colors.accentSoft else colors.danger.copy(alpha = 0.14f)
+            val stripBorder = if (isValid) colors.accentGhost else colors.danger.copy(alpha = 0.24f)
+            val stripIcon = if (isValid) Icons.Outlined.Check else Icons.Outlined.Warning
+            val stripIconColor = if (isValid) colors.accent else colors.danger
+            val stripText = if (isValid) validMsg else errorMsg!!
+
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = stripBg,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(1.dp, stripBorder, RoundedCornerShape(12.dp)),
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Icon(
+                        imageVector = stripIcon,
+                        contentDescription = null,
+                        tint = stripIconColor,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        text = stripText,
+                        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = stripIconColor,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+        }
+
+        // CTA button (accent glow shadow when enabled, 50% alpha when disabled)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (isValid)
+                        Modifier.shadow(
+                            elevation = 14.dp,
+                            shape = RoundedCornerShape(16.dp),
+                            clip = false,
+                            spotColor = colors.liveGlow,
+                        )
+                    else
+                        Modifier,
+                ),
+        ) {
+            Button(
+                onClick = {
+                    val lat = latDouble ?: return@Button
+                    val lng = lngDouble ?: return@Button
+                    val displayName = manualPrefixTemplate.format(
+                        name.ifBlank { "$lat, $lng" }
+                    )
+                    onSubmit(MockLocation(name = displayName, lat = lat, long = lng))
+                },
+                enabled = isValid,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .testTag("cta_button"),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = colors.accent,
+                    contentColor = colors.accentInk,
+                    disabledContainerColor = colors.accent.copy(alpha = 0.5f),
+                    disabledContentColor = colors.accentInk.copy(alpha = 0.5f),
+                ),
+            ) {
+                Icon(
+                    imageVector = MockIcons.Pin,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    text = stringResource(R.string.btn_set_mock_location_new),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+
+        // Tip line
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.tip_paste),
+            style = MaterialTheme.typography.labelMedium,
+            color = colors.textMute,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Light")
+@Composable
+private fun AddMockLocationBottomSheetPreviewLight() {
+    MockLocationTheme {
+        AddMockLocationBottomSheet(onSubmit = {})
+    }
+}
+
+@Preview(showBackground = true, name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AddMockLocationBottomSheetPreviewDark() {
+    MockLocationTheme {
+        AddMockLocationBottomSheet(onSubmit = {})
     }
 }


### PR DESCRIPTION
## Redesign custom coordinates bottom sheet

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt (rewrite)
- app/src/androidTest/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheetTest.kt (rewrite)

Goal:
Rewrite the bottom sheet content composable with styled text fields, a live validation strip, paste-to-split behavior, and branded CTA — while maintaining the same external function signature so the parent screen does not need modification.

Acceptance criteria:
- Composable function signature remains: fun AddMockLocationBottomSheet(modifier: Modifier = Modifier, onSubmit: (location: MockLocation) -> Unit) — do NOT rename or add parameters
- The parent (MockLocationScreen.kt) wraps this composable inside a ModalBottomSheet — this composable is the sheet CONTENT only, not the sheet itself. The ModalBottomSheet is configured by the parent with 28dp top corners, scrim, and drag handle
- Content padding: 20dp horizontal, 10dp top, 28dp bottom + navigationBarsPadding()
- Title row (Row, space-between): "Custom location" (22sp/700/-0.5sp, text color) on left, 32dp IconButton with Icons.Outlined.Close on right (textDim tint). Note: the close button should NOT call onSubmit — it has no effect since the parent controls sheet dismissal via scrim/drag. If no dismiss callback is available, omit the close button's onClick or have it do nothing visible (the parent's scrim tap handles dismissal)
- Subtitle: "Enter a label and coordinates. Saved to your library." (13sp/500, textDim), 4dp bottom spacing
- Name OutlinedTextField: overline label "NAME" (11sp/700/1.6sp uppercase, textDim) above the field (not as the TextField label — use a separate Text composable). Field height ~54dp, shape RoundedCornerShape(14.dp), colors: containerColor=chipBg, unfocusedBorderColor=borderStrong, focusedBorderColor=accent. Supporting text below: "A friendly label for your library." (11sp, textMute). KeyboardOptions: KeyboardType.Text, ImeAction.Next
- Latitude + Longitude row (Row, weight(1f) each, 10dp gap): same styling as Name field but with overline labels "LATITUDE" / "LONGITUDE", KeyboardType.Number (with signed decimal), supporting text "−90 to 90" / "−180 to 180". Text input uses JetBrains Mono font family
- Validation strip (12dp top spacing): Surface with RoundedCornerShape(12.dp). When both lat and lng parse as valid doubles in range: accentSoft fill, 1dp accentGhost border, Row with Icons.Outlined.Check (accent, 16dp) + "Valid coordinates · Closest city: <name>" (12sp/600, accent). When either is invalid: danger equivalent fill/border, error icon + specific message ("Latitude out of range" if lat parses but is outside [-90,90]; "Longitude out of range" similarly; "Invalid latitude" / "Invalid longitude" if they don't parse as numbers; show nothing if both fields are empty)
- "Closest city" lookup: iterate the 16 preset locations from app/src/main/assets/m_l.json and find the one with minimum great-circle distance. Since the composable doesn't have direct access to the presets list, compute it using a hardcoded list of the 16 preset lat/lng pairs, or use a simpler approach and just show "Valid coordinates" without the closest-city part if access to the preset list is impractical
- CTA button (12dp top spacing): Button, fillMaxWidth, 56dp height, RoundedCornerShape(16.dp), accent containerColor, accentInk contentColor, shadow(elevation=14.dp, spotColor=liveGlow, shape=RoundedCornerShape(16.dp)). Content: MockIcons.Pin (18dp) + 8dp spacer + "Set mock location" (16sp/600). Enabled only when both lat and lng are valid numbers in range. Disabled state: 50% alpha on the button
- Tip line (8dp top, centered): "Tip: paste 37.7749, −122.4194 into any field" (12sp/500, textMute)
- Paste-split behavior: in the onValueChange handler for latitude and longitude fields, check if the new value contains a comma. If so, split on "," (trim whitespace), put the first part in latitude and the second in longitude. This handles the case where the user pastes a coordinate pair like "37.7749, -122.4194" into either field
- On valid submit: call onSubmit with MockLocation(name = displayName, lat = parsedLat, long = parsedLong) where displayName uses the existing format from string resource manual_location_prefix: "(Manual) <name or lat, lng>"
- All colors from LocalMockColors.current, typography from MaterialTheme.typography
- All user-visible strings use stringResource()
- @Preview annotations for light + dark mode
- Instrumentation test rewrites: verify name/lat/lng fields render and accept input, verify validation strip shows error for out-of-range latitude, verify CTA button is disabled when fields are empty and enabled when valid, verify onSubmit callback fires with correct MockLocation on button click
- ./gradlew :app:compileDebugKotlin succeeds

Out of scope:
- Do not modify MockLocationScreen.kt — the ModalBottomSheet wrapper, sheet state, and dismiss handling remain in the parent
- Do not modify any other composable file, ViewModel, UiState, or domain classes
- Do not modify theme files, strings.xml, or icons

Context:
Refer to design_requirement/README.md section "3. Custom coordinates — Bottom sheet" for complete layout spec.

The current AddMockLocationBottomSheet.kt is a Column with 3 OutlinedTextFields (name, lat, lng), validation on submit, and a Button. The rewrite keeps the same data flow (3 text inputs → validation → MockLocation output) but adds visual polish: themed field styling with overline labels, a live inline validation strip, paste-split, and a branded CTA. The existing validation rules are unchanged: lat in [-90, 90], lng in [-180, 180], dot decimal separator. The current code validates only on button press — the redesign validates live (on every keystroke) to drive the validation strip and CTA enabled state.

The current composable's onSubmit callback is called by the parent as: AddMockLocationBottomSheet { location -> viewModel.onManualLocation(location, service); sheetState.hide() }. The parent also shows a Snackbar after submission — the redesign spec mentions showing "Added <name> to your library" as a Snackbar, but that is the parent's responsibility, not this composable's.

For the JetBrains Mono font in coordinate fields: import the JetBrainsMonoFamily from the Typography.kt file in the theme package (added in the Wave 1 theme task).

---

Jira: [ARC-153](https://randheercode.atlassian.net/browse/ARC-153)
