### PR TITLE
ARC-156: Add SortOrder enum and integrate sorting into UiState and UiStateMapper

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/SortOrder.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/SortOrder.kt
@@ -1,0 +1,3 @@
+package dev.randheer094.dev.location.presentation.mocklocation.state
+
+enum class SortOrder { A_TO_Z, Z_TO_A }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
@@ -31,6 +31,7 @@ data class UiState(
     val items: List<UiItem>,
     val elapsedLabel: String = "",
     val selected: MockLocation? = null,
+    val sortOrder: SortOrder = SortOrder.A_TO_Z,
 ) {
     companion object {
         val Empty = UiState(
@@ -40,6 +41,7 @@ data class UiState(
             items = emptyList(),
             elapsedLabel = "",
             selected = null,
+            sortOrder = SortOrder.A_TO_Z,
         )
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
@@ -11,14 +11,19 @@ object UiStateMapper {
         locations: List<MockLocation>,
         hasNotificationPermission: Boolean,
         elapsedLabel: String,
+        sortOrder: SortOrder = SortOrder.A_TO_Z,
     ): UiState {
+        val sortedLocations = when (sortOrder) {
+            SortOrder.A_TO_Z -> locations.sortedBy { it.name }
+            SortOrder.Z_TO_A -> locations.sortedByDescending { it.name }
+        }
         val items = buildList {
             add(SectionHeader.MockLocationStatus(isOn = status))
             add(MockLocationNStatus(selected, status))
-            if (locations.isNotEmpty()) {
+            if (sortedLocations.isNotEmpty()) {
                 add(SectionHeader.SelectLocations)
             }
-            addAll(locations.map { Location(it) })
+            addAll(sortedLocations.map { Location(it) })
         }
 
         return UiState(
@@ -28,6 +33,7 @@ object UiStateMapper {
             items = items,
             elapsedLabel = elapsedLabel,
             selected = selected,
+            sortOrder = sortOrder,
         )
     }
 


### PR DESCRIPTION
## Add SortOrder enum and integrate sorting into UiState and UiStateMapper

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/SortOrder.kt (new file)
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt

Goal:
Introduce a SortOrder enum and make UiStateMapper sort the preset-location list by name, so that downstream tasks can wire a toggle through the ViewModel and UI.

Acceptance criteria:
- New file `SortOrder.kt` in package `dev.randheer094.dev.location.presentation.mocklocation.state` contains `enum class SortOrder { A_TO_Z, Z_TO_A }`
- `UiState` data class has a new field `val sortOrder: SortOrder = SortOrder.A_TO_Z`
- `UiState.Empty` companion includes `sortOrder = SortOrder.A_TO_Z`
- `UiStateMapper.mapToUiState` accepts a new parameter `sortOrder: SortOrder = SortOrder.A_TO_Z` (default value is critical — existing callers must compile without changes)
- Inside the mapper, before mapping locations to `Location` items, the list is sorted: `A_TO_Z` → `sortedBy { it.name }`, `Z_TO_A` → `sortedByDescending { it.name }`
- The mapper passes the `sortOrder` value through into the returned `UiState`
- `./gradlew :app:compileDebugKotlin` passes
- `./gradlew :app:testDebugUnitTest` passes (existing tests use alphabetically-ordered test data and will continue to pass with the A_TO_Z default)

Out of scope:
- Do not modify MockLocationViewModel.kt, MockLocationScreen.kt, SectionHeader.kt, AddMockLocationBottomSheet.kt, strings.xml, or any test files
- Do not add DataStore persistence for sort order
- Do not add sort criteria beyond name-based A-Z / Z-A

Context:
The mapper is a pure-function object (`UiStateMapper`) with no Android dependencies. Its `mapToUiState` function currently builds the item list by mapping locations as-is at line 21: `addAll(locations.map { Location(it) })`. Insert the sort step before that mapping. The only current caller of `mapToUiState` is `MockLocationViewModel.kt` line 83 — because the new param has a default value, that call site compiles unchanged. A sibling task will later update the ViewModel to pass an explicit sort order. The existing unit tests in `UiStateMapperTest.kt` use fixtures named London, New York, and Tokyo which are already in alphabetical order, so the default A_TO_Z sort will not change their output.

---

Jira: [ARC-156](https://randheercode.atlassian.net/browse/ARC-156)
