### PR TITLE
ARC-155: Wire onDismiss callback on custom-coordinates bottom sheet close button

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
@@ -89,6 +89,7 @@ private fun closestCityName(lat: Double, lng: Double): String {
 @Composable
 fun AddMockLocationBottomSheet(
     modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
     onSubmit: (location: MockLocation) -> Unit,
 ) {
     val colors = LocalMockColors.current
@@ -154,12 +155,12 @@ fun AddMockLocationBottomSheet(
                 color = colors.text,
             )
             IconButton(
-                onClick = {},
+                onClick = onDismiss,
                 modifier = Modifier.size(32.dp),
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Close,
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.cd_close_sheet),
                     tint = colors.textDim,
                     modifier = Modifier.size(20.dp),
                 )
@@ -395,7 +396,7 @@ fun AddMockLocationBottomSheet(
 @Composable
 private fun AddMockLocationBottomSheetPreviewLight() {
     MockLocationTheme {
-        AddMockLocationBottomSheet(onSubmit = {})
+        AddMockLocationBottomSheet(onDismiss = {}, onSubmit = {})
     }
 }
 
@@ -403,6 +404,6 @@ private fun AddMockLocationBottomSheetPreviewLight() {
 @Composable
 private fun AddMockLocationBottomSheetPreviewDark() {
     MockLocationTheme {
-        AddMockLocationBottomSheet(onSubmit = {})
+        AddMockLocationBottomSheet(onDismiss = {}, onSubmit = {})
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
@@ -187,12 +187,15 @@ private fun HomeLayout(
                 onDismissRequest = { scope.launch { sheetState.hide() } },
                 containerColor = colors.bgElev,
             ) {
-                AddMockLocationBottomSheet { location ->
-                    scope.launch {
-                        viewModel.onManualLocation(location, service)
-                        sheetState.hide()
-                    }
-                }
+                AddMockLocationBottomSheet(
+                    onDismiss = { scope.launch { sheetState.hide() } },
+                    onSubmit = { location ->
+                        scope.launch {
+                            viewModel.onManualLocation(location, service)
+                            sheetState.hide()
+                        }
+                    },
+                )
             }
         }
         BackHandler(sheetState.isVisible) { scope.launch { sheetState.hide() } }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="cd_edit_location">Edit location</string>
     <string name="cd_start_mocking">Start mocking</string>
     <string name="cd_stop_mocking">Stop mocking</string>
+    <string name="cd_close_sheet">Close</string>
 
     <!-- Home screen -->
     <string name="wordmark_mock">mock</string>


### PR DESCRIPTION
## Wire onDismiss callback on custom-coordinates bottom sheet close button

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/AddMockLocationBottomSheet.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
- app/src/main/res/values/strings.xml

Goal:
Make the X (close) button on the custom-coordinates bottom sheet actually dismiss the sheet, matching the existing drag-down and back-gesture dismiss behavior.

Acceptance criteria:
- AddMockLocationBottomSheet composable accepts an `onDismiss: () -> Unit` parameter alongside the existing `onSubmit` parameter
- The IconButton at the top-right of the sheet (Icons.Outlined.Close) calls `onDismiss` on click (currently `onClick = {}`)
- The Close icon has `contentDescription = stringResource(R.string.cd_close_sheet)`
- MockLocationScreen's HomeLayout passes `onDismiss = { scope.launch { sheetState.hide() } }` — reusing the same coroutine-based dismiss path already used by `onDismissRequest` and `BackHandler`
- The two @Preview functions at the bottom of AddMockLocationBottomSheet.kt pass `onDismiss = {}`
- strings.xml contains `<string name="cd_close_sheet">Close</string>`
- `./gradlew :app:compileDebugKotlin` passes

Out of scope:
- Do not modify SectionHeader.kt, MockLocationViewModel.kt, UiState.kt, UiStateMapper.kt, or any test files
- Do not change the sort label or add sort behavior
- Do not change the ModalBottomSheet's onDismissRequest or BackHandler logic — only wire the close IconButton

Context:
The bottom sheet is shown via `ModalBottomSheet` in `MockLocationScreen.kt` HomeLayout (line 184-197). The sheet's dismiss is driven by `scope.launch { sheetState.hide() }` which is already used in two places: `onDismissRequest` (line 187) and `BackHandler` (line 198). The close IconButton in AddMockLocationBottomSheet.kt (line 156-166) currently has `onClick = {}` — a noop. The composable currently uses a trailing-lambda style for `onSubmit`; you will need to switch to explicit named parameters when calling it in MockLocationScreen.kt since there will now be two lambda params. The call site is at MockLocationScreen.kt line 190-195.

---

Jira: [ARC-155](https://randheercode.atlassian.net/browse/ARC-155)
