### PR TITLE
ARC-158: Add UiStateMapper sort-order test cases

### DIFF
--- a/app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt
+++ b/app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt
@@ -293,4 +293,61 @@ class UiStateMapperTest {
         assertEquals("??", UiStateMapper.getCountryCode("London, UK"))
         assertEquals("??", UiStateMapper.getCountryCode("NoCommaHere"))
     }
+
+    @Test
+    fun `A_TO_Z sort order produces locations sorted alphabetically ascending`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = listOf(tokyo, london, newYork),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+            sortOrder = SortOrder.A_TO_Z,
+        )
+
+        val locationItems = state.items.filterIsInstance<Location>().map { it.location }
+        assertEquals(listOf(london, newYork, tokyo), locationItems)
+    }
+
+    @Test
+    fun `Z_TO_A sort order produces locations sorted reverse-alphabetically descending`() {
+        val state = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = listOf(tokyo, london, newYork),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+            sortOrder = SortOrder.Z_TO_A,
+        )
+
+        val locationItems = state.items.filterIsInstance<Location>().map { it.location }
+        assertEquals(listOf(tokyo, newYork, london), locationItems)
+    }
+
+    @Test
+    fun `sortOrder is reflected in UiState`() {
+        val stateAtoZ = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+            sortOrder = SortOrder.A_TO_Z,
+        )
+        val stateZtoA = UiStateMapper.mapToUiState(
+            showInstructions = false,
+            status = false,
+            selected = null,
+            locations = emptyList(),
+            hasNotificationPermission = true,
+            elapsedLabel = "",
+            sortOrder = SortOrder.Z_TO_A,
+        )
+
+        assertEquals(SortOrder.A_TO_Z, stateAtoZ.sortOrder)
+        assertEquals(SortOrder.Z_TO_A, stateZtoA.sortOrder)
+    }
 }


### PR DESCRIPTION
## Add UiStateMapper sort-order test cases

Files to change:
- app/src/test/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapperTest.kt

Goal:
Add unit tests that verify UiStateMapper sorts the preset-location list correctly for both A_TO_Z and Z_TO_A sort orders.

Acceptance criteria:
- At least one test passes an intentionally-unordered list of MockLocation items with `sortOrder = SortOrder.A_TO_Z` and asserts the resulting Location items are sorted alphabetically by name (ascending)
- At least one test passes the same unordered list with `sortOrder = SortOrder.Z_TO_A` and asserts the resulting Location items are sorted reverse-alphabetically by name (descending)
- At least one test verifies that `UiState.sortOrder` reflects the value passed to the mapper
- All new tests use the existing test fixture style (private val MockLocation instances, JUnit 4 @Test, assertEquals/assertTrue assertions)
- `./gradlew :app:testDebugUnitTest` passes

Out of scope:
- Do not modify any file other than UiStateMapperTest.kt
- Do not add instrumentation tests or Compose UI tests
- Do not test ViewModel behavior or SectionHeader rendering

Context:
A prior task added a `sortOrder: SortOrder = SortOrder.A_TO_Z` parameter to `UiStateMapper.mapToUiState()` and a `sortOrder` field to `UiState`. The `SortOrder` enum lives in `dev.randheer094.dev.location.presentation.mocklocation.state.SortOrder` with values `A_TO_Z` and `Z_TO_A`.

The existing test class already has three MockLocation fixtures: `london` (London), `newYork` (New York), `tokyo` (Tokyo). These are alphabetical by coincidence. For the sort tests, use a deliberately non-alphabetical input order like `listOf(tokyo, london, newYork)` to make the assertion meaningful. Extract Location items from the result via `state.items.filterIsInstance<Location>().map { it.location }` — this pattern is already used in the existing `locations are mapped in order to Location items` test. The mapper signature is: `mapToUiState(showInstructions, status, selected, locations, hasNotificationPermission, elapsedLabel, sortOrder)`.

---

Jira: [ARC-158](https://randheercode.atlassian.net/browse/ARC-158)
