### PR TITLE
ARC-157: Wire sort toggle through ViewModel, SectionHeader, and screen

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
@@ -15,6 +15,7 @@ import dev.randheer094.dev.location.domain.SelectedMockLocationUseCase
 import dev.randheer094.dev.location.domain.SetMockLocationStatusUseCase
 import dev.randheer094.dev.location.domain.SetSetupInstructionStatusUseCase
 import dev.randheer094.dev.location.domain.SetupInstructionStatusUseCase
+import dev.randheer094.dev.location.presentation.mocklocation.state.SortOrder
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiState
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiStateMapper
 import dev.randheer094.dev.location.presentation.service.IMockLocationService
@@ -24,6 +25,7 @@ import dev.randheer094.dev.location.presentation.utils.PermissionUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -54,6 +56,15 @@ class MockLocationViewModel(
         private const val STOP_TIMEOUT_MILLIS = 5_000L
     }
 
+    private val sortOrderFlow = MutableStateFlow(SortOrder.A_TO_Z)
+
+    fun toggleSortOrder() {
+        sortOrderFlow.value = when (sortOrderFlow.value) {
+            SortOrder.A_TO_Z -> SortOrder.Z_TO_A
+            SortOrder.Z_TO_A -> SortOrder.A_TO_Z
+        }
+    }
+
     private val elapsedLabelFlow: Flow<String> = dataStore.data
         .map { it[MOCK_STARTED_AT] ?: 0L }
         .flatMapLatest { startedAt ->
@@ -76,17 +87,21 @@ class MockLocationViewModel(
             mockLocationStatusUseCase.execute(),
             selectedMockLocationUseCase.execute(),
         ) { showInstructions, status, selected -> Triple(showInstructions, status, selected) },
-        getMockLocationsUseCase.execute(),
+        combine(
+            getMockLocationsUseCase.execute(),
+            sortOrderFlow,
+        ) { locations, sortOrder -> Pair(locations, sortOrder) },
         permissionUtils.getNotificationPermissionState(),
         elapsedLabelFlow,
-    ) { triple, locations, notiPermissionState, elapsedLabel ->
+    ) { triple, locationsWithSort, notiPermissionState, elapsedLabel ->
         uiStateMapper.mapToUiState(
             showInstructions = triple.first,
             status = triple.second,
             selected = triple.third,
-            locations = locations,
+            locations = locationsWithSort.first,
             hasNotificationPermission = notiPermissionState.isGranted,
             elapsedLabel = elapsedLabel,
+            sortOrder = locationsWithSort.second,
         )
     }.distinctUntilChanged().flowOn(Dispatchers.Default).stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
@@ -160,7 +160,7 @@ private fun HomeLayout(
                 }
 
                 item {
-                    SectionHeader()
+                    SectionHeader(sortOrder = state.sortOrder, onToggleSort = viewModel::toggleSortOrder)
                 }
 
                 items(locations, key = { it.name }) { location ->

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SectionHeader.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SectionHeader.kt
@@ -1,6 +1,7 @@
 package dev.randheer094.dev.location.presentation.mocklocation.composable
 
 import android.content.res.Configuration
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -19,12 +21,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.randheer094.dev.location.R
+import dev.randheer094.dev.location.presentation.mocklocation.state.SortOrder
 import dev.randheer094.dev.location.presentation.theme.InterFamily
 import dev.randheer094.dev.location.presentation.theme.LocalMockColors
 import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
 
 @Composable
-fun SectionHeader(modifier: Modifier = Modifier) {
+fun SectionHeader(
+    sortOrder: SortOrder,
+    onToggleSort: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val colors = LocalMockColors.current
 
     Row(
@@ -48,9 +55,10 @@ fun SectionHeader(modifier: Modifier = Modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier.clickable(onClick = onToggleSort),
         ) {
             Text(
-                text = stringResource(R.string.label_sort_az),
+                text = if (sortOrder == SortOrder.A_TO_Z) stringResource(R.string.label_sort_az) else stringResource(R.string.label_sort_za),
                 style = TextStyle(
                     fontFamily = InterFamily,
                     fontWeight = FontWeight.Medium,
@@ -62,7 +70,7 @@ fun SectionHeader(modifier: Modifier = Modifier) {
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,
                 tint = colors.textDim,
-                modifier = Modifier.padding(0.dp),
+                modifier = Modifier.padding(0.dp).rotate(if (sortOrder == SortOrder.Z_TO_A) 180f else 0f),
             )
         }
     }
@@ -72,7 +80,7 @@ fun SectionHeader(modifier: Modifier = Modifier) {
 @Composable
 private fun SectionHeaderLightPreview() {
     MockLocationTheme(darkTheme = false) {
-        SectionHeader()
+        SectionHeader(sortOrder = SortOrder.A_TO_Z, onToggleSort = {})
     }
 }
 
@@ -80,6 +88,6 @@ private fun SectionHeaderLightPreview() {
 @Composable
 private fun SectionHeaderDarkPreview() {
     MockLocationTheme(darkTheme = true) {
-        SectionHeader()
+        SectionHeader(sortOrder = SortOrder.A_TO_Z, onToggleSort = {})
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="overline_currently_spoofing">CURRENTLY SPOOFING</string>
     <string name="section_preset_locations">PRESET LOCATIONS</string>
     <string name="label_sort_az">Sort · A–Z</string>
+    <string name="label_sort_za">Sort · Z–A</string>
     <string name="btn_stop_broadcasting">Stop broadcasting</string>
     <string name="badge_live">LIVE</string>
     <string name="overline_last_used">LAST USED</string>


### PR DESCRIPTION
## Wire sort toggle through ViewModel, SectionHeader, and screen

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SectionHeader.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
- app/src/main/res/values/strings.xml

Goal:
Make the "Sort · A–Z" section header clickable so it toggles between A–Z and Z–A sort order, re-ordering the preset-location list on each tap.

Acceptance criteria:
- MockLocationViewModel has a private `MutableStateFlow<SortOrder>(SortOrder.A_TO_Z)` field
- MockLocationViewModel exposes a `fun toggleSortOrder()` that flips the flow value between A_TO_Z and Z_TO_A
- The ViewModel's `combine` block feeds `sortOrder` into `uiStateMapper.mapToUiState(...)` via the `sortOrder` parameter (there are already 4 flows combined; nest the mock-locations flow with the sort-order flow into a `Pair` upstream to avoid exceeding the 5-arg `combine` overload)
- SectionHeader composable accepts two new parameters: `sortOrder: SortOrder` and `onToggleSort: () -> Unit`
- The inner Row containing the sort label and chevron icon is wrapped with `Modifier.clickable(onClick = onToggleSort)`
- The sort label text reads `stringResource(R.string.label_sort_az)` when `sortOrder == A_TO_Z`, or `stringResource(R.string.label_sort_za)` when `Z_TO_A`
- The chevron icon rotates 180° when sortOrder is Z_TO_A (use `Modifier.rotate(if (sortOrder == SortOrder.Z_TO_A) 180f else 0f)`)
- SectionHeader's two @Preview functions pass `sortOrder = SortOrder.A_TO_Z` and `onToggleSort = {}`
- MockLocationScreen's HomeLayout calls `SectionHeader(sortOrder = state.sortOrder, onToggleSort = viewModel::toggleSortOrder)`
- strings.xml contains `<string name="label_sort_za">Sort · Z–A</string>` (the existing `label_sort_az` string stays)
- `./gradlew :app:compileDebugKotlin` passes

Out of scope:
- Do not modify AddMockLocationBottomSheet.kt, UiState.kt, UiStateMapper.kt, SortOrder.kt, or test files
- Do not persist sort order to DataStore
- Do not add sort criteria beyond name A-Z / Z-A
- Do not change TopBar, HeroCard, LocationRow, or any other composable

Context:
A prior task has already added: `SortOrder` enum in `state/SortOrder.kt` with values `A_TO_Z` and `Z_TO_A`; a `sortOrder: SortOrder = SortOrder.A_TO_Z` parameter on `UiStateMapper.mapToUiState`; and a `sortOrder` field on `UiState`. This task wires those through the ViewModel and UI.

In MockLocationViewModel.kt, the current `combine` at line 73 nests a 3-flow combine into a Triple, then combines with 3 more flows (getMockLocationsUseCase.execute(), permissionUtils, elapsedLabelFlow) in an outer 4-arg combine. To add sortOrderFlow: combine `getMockLocationsUseCase.execute()` with `sortOrderFlow` into a `Pair<List<MockLocation>, SortOrder>` upstream, then use that Pair in the outer combine instead of the raw locations flow. Extract `.first` for the locations list and `.second` for the sort order when calling the mapper.

SectionHeader.kt currently has a parameterless `@Composable fun SectionHeader(modifier: Modifier = Modifier)`. The sort label at line 53 is hardcoded to `stringResource(R.string.label_sort_az)`. The Row containing the label and chevron (lines 48-67) is not clickable. You will need to import `SortOrder` from the state package, `androidx.compose.foundation.clickable`, and `androidx.compose.ui.draw.rotate`.

In MockLocationScreen.kt, SectionHeader is called at line 163 with no arguments inside a `LazyColumn` item block. Pass the two new params there.

---

Jira: [ARC-157](https://randheercode.atlassian.net/browse/ARC-157)
