### PR TITLE
ARC-200: Fix service crash on null intent and background stop IllegalStateException

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
@@ -72,14 +72,26 @@ class MockLocationService : Service(), IMockLocationService {
                 }
 
                 startMocking(MockLocation(name = name, lat = lat, long = lng))
+                return START_STICKY
             }
             ACTION_STOP -> {
                 stopMocking()
                 stopSelf()
                 return START_NOT_STICKY
             }
+            else -> {
+                // Null or unrecognized intent — Android re-delivered after killing a
+                // START_STICKY service. Satisfy the foreground contract then stop so the
+                // service doesn't linger with no work to do.
+                notificationUtils.createNotificationChannel()
+                startForeground(
+                    NotificationUtils.NOTIFICATION_ID,
+                    notificationUtils.createForegroundNotification(lat = 0.0, long = 0.0),
+                )
+                stopSelf()
+                return START_NOT_STICKY
+            }
         }
-        return START_STICKY
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationServiceStarter.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationServiceStarter.kt
@@ -30,6 +30,6 @@ class MockLocationServiceStarter(private val context: Context) {
         val intent = Intent(context, MockLocationService::class.java).apply {
             action = MockLocationService.ACTION_STOP
         }
-        context.startService(intent)
+        ContextCompat.startForegroundService(context, intent)
     }
 }


### PR DESCRIPTION
## Fix service crash on null intent and background stop IllegalStateException

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationServiceStarter.kt

Goal:
Prevent two service-related crashes: (a) Android 14+ crash when the system re-delivers a null intent after killing the service, and (b) IllegalStateException when stopping the service from a backgrounded process on Android 12+.

Acceptance criteria:
- In MockLocationService.onStartCommand, when intent is null or intent.action is unrecognized (neither ACTION_START nor ACTION_STOP), the service promotes to foreground with a minimal notification and returns START_NOT_STICKY so Android does not re-deliver the null intent
- The final return START_STICKY on line 82 is removed; each branch returns its own start mode explicitly
- In MockLocationServiceStarter.stop(), context.startService(intent) is replaced with ContextCompat.startForegroundService(context, intent) so the call does not throw IllegalStateException from a backgrounded process on Android 12+
- Existing unit and instrumentation tests still pass

Out of scope:
- NotificationUtils changes
- MockLocationScreen or ViewModel changes
- Build script or dependency changes
- Any files outside the two listed service files

Context:
MockLocationService.onStartCommand (line 54) has a when block matching ACTION_START and ACTION_STOP. When Android re-delivers the intent after killing a START_STICKY service, intent is null and no branch matches. The method falls through to return START_STICKY on line 82 without ever calling startForeground(). On Android 14+, the system enforces that startForegroundService must call startForeground within 5 seconds or it crashes with ForegroundServiceStartNotAllowedException.

The fix for the null/unknown case: call notificationUtils.createNotificationChannel() then startForeground(NotificationUtils.NOTIFICATION_ID, notificationUtils.createForegroundNotification(0.0, 0.0)) to satisfy the foreground contract, then stopSelf() and return START_NOT_STICKY. This matches the existing pattern used in the NaN-coordinates branch on lines 65-71.

For MockLocationServiceStarter.stop() (line 30-34), the current code uses context.startService(intent) to send ACTION_STOP. On Android 12+ (API 31+), if the app is in the background, startService throws IllegalStateException due to background start restrictions. The fix is to use ContextCompat.startForegroundService(context, intent) instead — the service already handles ACTION_STOP by stopping itself, and the foreground promotion is immediately followed by stopSelf(). The import for ContextCompat is already present in MockLocationServiceStarter.kt.

---

Jira: [ARC-200](https://randheercode.atlassian.net/browse/ARC-200)
