### PR TITLE
ARC-201: Hide spoofed coordinates from lockscreen notification

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/utils/NotificationUtils.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/utils/NotificationUtils.kt
@@ -37,6 +37,7 @@ class NotificationUtils(private val context: Context) {
             .setSmallIcon(R.drawable.ic_location)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
+            .setVisibility(NotificationCompat.VISIBILITY_SECRET)
             .setContentIntent(buildContentIntent())
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .setSilent(true)


### PR DESCRIPTION
## Hide spoofed coordinates from lockscreen notification

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/utils/NotificationUtils.kt

Goal:
Prevent the persistent foreground notification from exposing exact latitude/longitude on the device lockscreen.

Acceptance criteria:
- The notification builder in createForegroundNotification sets visibility to VISIBILITY_SECRET so the notification is hidden on the lockscreen
- When the device is unlocked, the notification still displays the coordinates as before
- Existing tests still pass

Out of scope:
- MockLocationService changes
- String resource changes (strings.xml)
- MockLocationScreen or ViewModel changes
- Build script or dependency changes

Context:
NotificationUtils.createForegroundNotification (line 33) builds a notification that includes exact lat/long in setContentText via the R.string.notification_content format string ("Latitude: %1$s, Longitude: %2$s"). This text is visible on the lockscreen, which leaks the spoofed coordinates to anyone who can see the device.

Add .setVisibility(NotificationCompat.VISIBILITY_SECRET) to the builder chain in createForegroundNotification — after .setOngoing(true) is a natural spot. This hides the notification entirely when the device is locked. Use the constant from NotificationCompat (not Notification) to maintain backward compatibility. This is appropriate for a developer tool — there is no user-facing reason to show mock coordinates on the lockscreen.

---

Jira: [ARC-201](https://randheercode.atlassian.net/browse/ARC-201)
