### PR TITLE
ARC-203: Document Koin exemption in architecture rules

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -45,21 +45,26 @@ All UI is Jetpack Compose.
 - Material 3 (`androidx.compose.material3`) is the design system;
   dynamic color on Android 12+, dark theme always supported.
 
-## DI: Hilt
+## DI: Koin
 
-Hilt is the DI framework.
+Koin is the DI framework for this project.
 
-- `Application` is `@HiltAndroidApp`. The host `Activity` is
-  `@AndroidEntryPoint`. ViewModels are `@HiltViewModel`.
-- Hilt's annotation processor runs through KSP, not kapt.
-- Collaborators reach the class via `@Inject constructor(...)`.
-- Bindings live in `@Module @InstallIn(<Component>::class)`; use
-  `@Binds` for interface→impl wiring.
-- Scope with intent: `@Singleton` for app-lifetime,
-  `@ActivityRetainedScoped` for ViewModel-shared state,
-  `@ViewModelScoped` for per-screen collaborators. Default to the
-  narrowest scope that works.
-- Tests use `@HiltAndroidTest` + `@UninstallModules` to swap fakes.
+> **Exemption note**: Hilt is the standard for multi-module Android
+> projects, but Koin is exempted here. This is a single-module app
+> and migrating to Hilt pre-release would be high-risk churn with no
+> user-facing benefit.
+
+- All bindings are declared in `di/MockLocationModules.kt` as a
+  single `appModule`. Use `single {}` for app-lifetime singletons,
+  `factory {}` for use cases, and `viewModel {}` for ViewModels.
+- `MockLocationApp.onCreate` calls
+  `startKoin { androidContext(this); modules(appModule) }` to
+  bootstrap the container.
+- Services and other non-Compose entry points use
+  `by inject<T>()` for lazy property injection.
+- Composables obtain ViewModels via `koinViewModel()` (or the
+  standard `viewModel()` delegate wired through Koin's ViewModel
+  integration).
 
 ## Coroutines & Flow
 


### PR DESCRIPTION
## Document Koin exemption in architecture rules

Files to change:
- .claude/rules/architecture.md

Goal:
Update the DI section of the architecture rules to reflect that the app uses Koin, not Hilt, with a documented exemption rationale.

Acceptance criteria:
- The "DI: Hilt" section heading (line 48) and its bullet points (lines 49-62) are replaced with a "DI: Koin" section that documents the current Koin usage patterns
- The new section documents: appModule declared in MockLocationModules.kt, startKoin called in Application.onCreate, inject via by inject<T>() in services, and single/factory/viewModel declarations in the module
- A brief note states that Hilt is the standard for multi-module Android projects but Koin is exempted for this single-module app since migration pre-release is not justified
- The existing MVI, Compose, and Coroutines & Flow sections are NOT modified

Out of scope:
- Any Kotlin source code changes — this is a documentation-only task, no actual DI migration
- Other rule files (testing.md, build.md, ui.md, etc.)
- CLAUDE.md at the repo root

Context:
The architecture.md rule file (lines 48-62) mandates Hilt with @HiltAndroidApp, @AndroidEntryPoint, @HiltViewModel, KSP processing, @Module @InstallIn, @Binds, and Hilt component scoping. The actual codebase uses Koin throughout: MockLocationApp calls startKoin { androidContext(this); modules(appModule) }, services use by inject<T>() for lazy injection, and the DI wiring lives in di/MockLocationModules.kt with single {}, factory {}, and viewModel {} declarations. Migrating from Koin to Hilt before a release is high-risk churn with no user-facing benefit. The fix is to align the documentation with reality and note the exemption.

---

Jira: [ARC-203](https://randheercode.atlassian.net/browse/ARC-203)
