### PR TITLE
ARC-202: Disable auto-backup of DataStore to Google Drive

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application
         android:name=".app.MockLocationApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     Auto backup rules (legacy Key/Value + Auto Backup used up to Android 11).
-    We explicitly include the DataStore Preferences file that stores the user's selected
-    mock location and setup flags so the user doesn't lose them on re-install.
+    Cloud backup is disabled — mock location coordinates are trivially reconstructable
+    by selecting a city or entering coordinates manually.
 -->
-<full-backup-content>
-    <include domain="file" path="datastore/m_l.preferences_pb" />
-</full-backup-content>
+<full-backup-content />

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Data extraction rules for Android 12+ (S+). Covers cloud auto-backup and device-to-device
-    transfer. We intentionally allow both for the small amount of state the app keeps:
-    the selected mock location and a couple of boolean preference flags.
+    Data extraction rules for Android 12+ (S+). Cloud backup is disabled — mock location
+    coordinates are trivially reconstructable. Device-to-device transfer during setup is
+    lower risk and kept enabled.
 -->
 <data-extraction-rules>
-    <cloud-backup>
-        <include domain="file" path="datastore/m_l.preferences_pb" />
-    </cloud-backup>
+    <cloud-backup />
     <device-transfer>
         <include domain="file" path="datastore/m_l.preferences_pb" />
     </device-transfer>


### PR DESCRIPTION
## Disable auto-backup of DataStore to Google Drive

Files to change:
- app/src/main/AndroidManifest.xml
- app/src/main/res/xml/backup_rules.xml
- app/src/main/res/xml/data_extraction_rules.xml

Goal:
Disable cloud backup so the DataStore preferences file containing selected coordinates is not shipped to Google Drive.

Acceptance criteria:
- android:allowBackup is set to "false" in AndroidManifest.xml (line 15)
- backup_rules.xml contains no include rules (empty full-backup-content element)
- data_extraction_rules.xml cloud-backup section contains no include rules; device-transfer section may optionally keep the include for DataStore (device-to-device transfer during setup is lower risk than cloud backup)
- The android:fullBackupContent and android:dataExtractionRules attributes remain in the manifest pointing to their respective XML files
- The app compiles and existing tests pass

Out of scope:
- Any Kotlin source code changes
- Build script changes
- String resource changes

Context:
The app currently ships android:allowBackup="true" with backup_rules.xml including datastore/m_l.preferences_pb. This DataStore file holds the user's selected mock location name, coordinates, and boolean preference flags. While not sensitive credentials, backing up mock coordinates to Google Drive is unnecessary for a developer tool — the data is trivially reconstructable by selecting a city from the bundled list or entering coordinates manually. Disabling backup is the safer default for a first public release.

The manifest also references android:dataExtractionRules="@xml/data_extraction_rules" which controls Android 12+ behavior. Update the cloud-backup section to remove the include, but keeping device-transfer enabled is acceptable. Keep both XML attributes in the manifest even if the sections are empty, as removing the attributes changes Android's default behavior.

---

Jira: [ARC-202](https://randheercode.atlassian.net/browse/ARC-202)
