### PR TITLE
ARC-204: Add contentDescription to icon-only buttons

### DIFF
--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
@@ -278,7 +278,7 @@ private fun TopBar(
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Add,
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.fab_add_location),
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
@@ -84,7 +84,7 @@ fun SetupInstruction(onGotIt: () -> Unit) {
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.cd_navigate_back),
                         tint = colors.text,
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="cd_start_mocking">Start mocking</string>
     <string name="cd_stop_mocking">Stop mocking</string>
     <string name="cd_close_sheet">Close</string>
+    <string name="cd_navigate_back">Navigate back</string>
 
     <!-- Home screen -->
     <string name="wordmark_mock">mock</string>


### PR DESCRIPTION
## Add contentDescription to icon-only buttons

Files to change:
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/SetupInstruction.kt
- app/src/main/res/values/strings.xml

Goal:
Provide accessible labels for the two icon-only interactive elements that currently pass null as contentDescription.

Acceptance criteria:
- The Add (plus) Icon inside the FilledIconButton in MockLocationScreen.kt TopBar composable (around line 280) uses stringResource(R.string.fab_add_location) as its contentDescription instead of null
- The back arrow Icon inside the IconButton in SetupInstruction.kt (around line 87) uses a string resource as its contentDescription instead of null
- A new string resource is added to strings.xml for the back navigation label (e.g. name="cd_navigate_back" with value "Navigate back"), placed near the other content description strings around line 43
- Decorative icons that are not interactive (e.g. the Pin icon in the wordmark row, the Info icon in the setup badge, the ArrowOutward in the button) keep contentDescription = null
- Existing tests still pass

Out of scope:
- Any logic or state changes in MockLocationScreen or SetupInstruction
- collectAsState to collectAsStateWithLifecycle migration (separate task)
- UiState or UiStateMapper changes
- Build script or dependency changes
- NotificationUtils changes

Context:
The project's ui.md rule requires every interactive element to have a contentDescription or Modifier.semantics, with touch targets >= 48dp. There is an existing string R.string.fab_add_location = "New location" that should be reused for the Add button's Icon contentDescription. For the back arrow in SetupInstruction, no existing string covers "navigate back" — add one under the "Content descriptions" comment section of strings.xml (near line 43 where cd_edit_location, cd_start_mocking, cd_stop_mocking, and cd_close_sheet live). The ArrowBack icon on SetupInstruction.kt line 86 is inside an IconButton (interactive), so it must have a contentDescription.

---

Jira: [ARC-204](https://randheercode.atlassian.net/browse/ARC-204)
