### PR TITLE
ARC-205: Harden build config and add debug tooling (Timber, LeakCanary, StrictMode)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "dev.randheer094.dev.location"
         minSdk = 28
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.0.0"
+        versionCode = 10 // intentional: first public upload
+        versionName = "1.0.0" // intentional: first public upload
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -66,15 +66,23 @@ android {
             )
             signingConfig = if (keystoreProperties.isNotEmpty()) {
                 signingConfigs.getByName("release")
+            } else if (System.getenv("CI") != null) {
+                error("Release signing requires keystore.properties on CI")
             } else {
                 // Fall back to the debug keystore so `assembleRelease` doesn't fail locally
-                // when keystore.properties is absent. CI must always provide real credentials.
+                // when keystore.properties is absent.
                 signingConfigs.getByName("debug")
             }
         }
     }
     buildFeatures {
         compose = true
+        buildConfig = true
+    }
+    lint {
+        abortOnError = true
+        warningsAsErrors = true
+        baseline = file("lint-baseline.xml")
     }
     testOptions {
         animationsDisabled = true
@@ -86,6 +94,7 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+            allWarningsAsErrors.set(true)
         }
     }
     packaging {
@@ -119,6 +128,8 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.permission.flow.android)
     implementation(libs.permission.flow.compose)
+    implementation(libs.timber)
+    debugImplementation(libs.leakcanary.android)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.0.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0)" variant="all" version="9.0.0">
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 31 (current min is 28): `android.location.provider.ProviderProperties#POWER_USAGE_LOW`"
+        errorLine1="                ProviderProperties.POWER_USAGE_LOW,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/dev/randheer094/dev/location/presentation/utils/LocationUtils.kt"
+            line="30"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 31 (current min is 28): `android.location.provider.ProviderProperties#ACCURACY_FINE`"
+        errorLine1="                ProviderProperties.ACCURACY_FINE"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/dev/randheer094/dev/location/presentation/utils/LocationUtils.kt"
+            line="31"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 9.1.0 is available: 9.5.0"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/wrapper/gradle-wrapper.properties"
+            line="4"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 9.0.0 is available: 9.2.0. (There is also a newer version of 9.0.𝑥 available, if upgrading to 9.2.0 is difficult: 9.0.1)"
+        errorLine1="agp = &quot;9.0.0&quot;"
+        errorLine2="      ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="2"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.17.0 is available: 1.18.0"
+        errorLine1="coreKtx = &quot;1.17.0&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="4"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.9.3 is available: 2.10.0"
+        errorLine1="lifecycleRuntimeKtx = &quot;2.9.3&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="5"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.10.1 is available: 1.13.0"
+        errorLine1="activityCompose = &quot;1.10.1&quot;"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="6"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2025.08.01 is available: 2026.04.01"
+        errorLine1="composeBom = &quot;2025.08.01&quot;"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="7"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.9.3 is available: 2.10.0"
+        errorLine1="lifecycleViewModelCompose = &quot;2.9.3&quot;"
+        errorLine2="                            ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="8"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.datastore:datastore than 1.1.7 is available: 1.2.1"
+        errorLine1="datastore = &quot;1.1.7&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.datastore:datastore-preferences than 1.1.7 is available: 1.2.1"
+        errorLine1="datastore = &quot;1.1.7&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:runner than 1.6.2 is available: 1.7.0"
+        errorLine1="androidxTestRunner = &quot;1.6.2&quot;"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="15"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.2.1 is available: 1.3.0"
+        errorLine1="androidxTestExtJunit = &quot;1.2.1&quot;"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="16"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:rules than 1.6.1 is available: 1.7.0"
+        errorLine1="androidxTestRules = &quot;1.6.1&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="17"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core-ktx than 1.6.1 is available: 1.7.0"
+        errorLine1="androidxTestCore = &quot;1.6.1&quot;"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="18"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.espresso:espresso-core than 3.6.1 is available: 3.7.0"
+        errorLine1="espresso = &quot;3.6.1&quot;"
+        errorLine2="           ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="19"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.android than 2.2.10 is available: 2.3.21"
+        errorLine1="kotlin = &quot;2.2.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.compose than 2.2.10 is available: 2.3.21"
+        errorLine1="kotlin = &quot;2.2.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.serialization than 2.2.10 is available: 2.3.21"
+        errorLine1="kotlin = &quot;2.2.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-serialization-json than 1.9.0 is available: 1.11.0"
+        errorLine1="kotlinSerialization = &quot;1.9.0&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="9"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.insert-koin:koin-android than 4.1.1 is available: 4.2.1"
+        errorLine1="koin = &quot;4.1.1&quot;"
+        errorLine2="       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="10"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.insert-koin:koin-android-test than 4.1.1 is available: 4.2.1"
+        errorLine1="koin = &quot;4.1.1&quot;"
+        errorLine2="       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="10"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.insert-koin:koin-androidx-compose than 4.1.1 is available: 4.2.1"
+        errorLine1="koin = &quot;4.1.1&quot;"
+        errorLine2="       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="10"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.insert-koin:koin-core than 4.1.1 is available: 4.2.1"
+        errorLine1="koin = &quot;4.1.1&quot;"
+        errorLine2="       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="10"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.insert-koin:koin-test than 4.1.1 is available: 4.2.1"
+        errorLine1="koin = &quot;4.1.1&quot;"
+        errorLine2="       ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="10"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.9.0 is available: 1.10.2"
+        errorLine1="kotlinxCoroutines = &quot;1.9.0&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            line="14"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 28. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location
+            file="src/main/res/mipmap-anydpi-v26"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.black` appears to be unused"
+        errorLine1="    &lt;color name=&quot;black&quot;>#FF000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="4"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.white` appears to be unused"
+        errorLine1="    &lt;color name=&quot;white&quot;>#FFFFFFFF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="5"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.font.inter` appears to be unused"
+        errorLine1="&lt;font-family xmlns:app=&quot;http://schemas.android.com/apk/res-auto&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/font/inter.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.font.jetbrains_mono` appears to be unused"
+        errorLine1="&lt;font-family xmlns:app=&quot;http://schemas.android.com/apk/res-auto&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/font/jetbrains_mono.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.setup_instructions_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;setup_instructions_title&quot;>Setup Instructions&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.setup_instructions_body` appears to be unused"
+        errorLine1="    &lt;string name=&quot;setup_instructions_body&quot;>Select Mock Location App:\n- Go to Settings &amp;gt; Developer options.\n- Scroll down and tap \&quot;Select mock location app\&quot;.\n- Choose this app from the list.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.setup_instructions_got_it` appears to be unused"
+        errorLine1="    &lt;string name=&quot;setup_instructions_got_it&quot;>Got it!&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.section_mock_location_status` appears to be unused"
+        errorLine1="    &lt;string name=&quot;section_mock_location_status&quot;>Mock location: (%1$s)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.status_on` appears to be unused"
+        errorLine1="    &lt;string name=&quot;status_on&quot;>ON&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.status_off` appears to be unused"
+        errorLine1="    &lt;string name=&quot;status_off&quot;>OFF&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.section_select_locations` appears to be unused"
+        errorLine1="    &lt;string name=&quot;section_select_locations&quot;>Select locations&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.add_or_select_location` appears to be unused"
+        errorLine1="    &lt;string name=&quot;add_or_select_location&quot;>Add Location or Select from list below&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.add_mock_location_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;add_mock_location_title&quot;>Add Mock Location&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.add_mock_location_subtitle` appears to be unused"
+        errorLine1="    &lt;string name=&quot;add_mock_location_subtitle&quot;>Enter a name and coordinates for the location you want to mock.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_name&quot;>Name&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_latitude` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_latitude&quot;>Latitude&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.label_longitude` appears to be unused"
+        errorLine1="    &lt;string name=&quot;label_longitude&quot;>Longitude&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.cta_set_mock_location` appears to be unused"
+        errorLine1="    &lt;string name=&quot;cta_set_mock_location&quot;>Set Mock Location&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.cd_edit_location` appears to be unused"
+        errorLine1="    &lt;string name=&quot;cd_edit_location&quot;>Edit location&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.cd_start_mocking` appears to be unused"
+        errorLine1="    &lt;string name=&quot;cd_start_mocking&quot;>Start mocking&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.cd_stop_mocking` appears to be unused"
+        errorLine1="    &lt;string name=&quot;cd_stop_mocking&quot;>Stop mocking&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.snackbar_added` appears to be unused"
+        errorLine1="    &lt;string name=&quot;snackbar_added&quot;>Added \&quot;%1$s\&quot; to your library&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="IconXmlAndPng"
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src/main/res/drawable-anydpi/ic_location.xml, src/main/res/drawable-hdpi/ic_location.webp">
+        <location
+            file="src/main/res/drawable-xxhdpi/ic_location.webp"/>
+        <location
+            file="src/main/res/drawable-xhdpi/ic_location.webp"/>
+        <location
+            file="src/main/res/drawable-mdpi/ic_location.webp"/>
+        <location
+            file="src/main/res/drawable-hdpi/ic_location.webp"/>
+        <location
+            file="src/main/res/drawable-anydpi/ic_location.xml"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive roundIcon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+</issues>

--- a/app/src/main/java/dev/randheer094/dev/location/app/MockLocationApp.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/app/MockLocationApp.kt
@@ -1,10 +1,13 @@
 package dev.randheer094.dev.location.app
 
 import android.app.Application
+import android.os.StrictMode
+import dev.randheer094.dev.location.BuildConfig
 import dev.randheer094.dev.location.di.appModule
 import dev.shreyaspatil.permissionFlow.PermissionFlow
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
+import timber.log.Timber
 
 class MockLocationApp : Application() {
     override fun onCreate() {
@@ -16,6 +19,21 @@ class MockLocationApp : Application() {
         startKoin {
             androidContext(this@MockLocationApp)
             modules(appModule)
+        }
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build()
+            )
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build()
+            )
         }
     }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
@@ -20,7 +20,7 @@ import dev.randheer094.dev.location.presentation.utils.NotificationUtils
 import dev.randheer094.dev.location.presentation.utils.PermissionUtils
 import dev.shreyaspatil.permissionFlow.PermissionFlow
 import kotlinx.serialization.json.Json
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/MockLocationViewModel.kt
@@ -34,8 +34,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MockLocationViewModel(
     getMockLocationsUseCase: GetMockLocationsUseCase,
     selectedMockLocationUseCase: SelectedMockLocationUseCase,

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/Radar.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/Radar.kt
@@ -32,6 +32,7 @@ import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
 fun Radar(modifier: Modifier = Modifier) {
     val colors = LocalMockColors.current
     var isRunning by remember { mutableStateOf(true) }
+    @Suppress("DEPRECATION")
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifecycleOwner) {

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.location.LocationManager
 import android.os.Binder
 import android.os.IBinder
-import android.util.Log
 import dev.randheer094.dev.location.domain.MockLocation
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
 import dev.randheer094.dev.location.presentation.utils.NotificationUtils
@@ -18,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
+import timber.log.Timber
 
 interface IMockLocationService {
     fun startMocking(location: MockLocation)
@@ -34,7 +34,6 @@ class MockLocationService : Service(), IMockLocationService {
     private var job: Job? = null
 
     companion object {
-        private const val TAG = "MockLocationService"
         private const val MOCK_LOCATION_UPDATE_INTERVAL_MS = 1000L
         const val ACTION_START = "dev.randheer094.dev.location.action.START"
         const val ACTION_STOP = "dev.randheer094.dev.location.action.STOP"
@@ -134,7 +133,7 @@ class MockLocationService : Service(), IMockLocationService {
                     // SecurityException can be thrown if the user removes this app as the
                     // mock location provider while we're running. Log and exit the loop so
                     // the service can be cleanly stopped by the UI/ViewModel.
-                    Log.w(TAG, "Failed to push mock location, stopping loop", it)
+                    Timber.w(it, "Failed to push mock location, stopping loop")
                     return@launch
                 }
                 delay(MOCK_LOCATION_UPDATE_INTERVAL_MS)

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/theme/Theme.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/theme/Theme.kt
@@ -20,6 +20,7 @@ fun MockLocationTheme(
 
     val view = LocalView.current
     if (!view.isInEditMode) {
+        @Suppress("DEPRECATION")
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = mockColors.bg.toArgb()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ androidxTestCore = "1.6.1"
 espresso = "3.6.1"
 androidxArchCoreTesting = "2.2.0"
 androidxUiAutomator = "2.3.0"
+timber = "5.0.1"
+leakcanary = "2.14"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -52,6 +54,8 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin" }
 koin-android-test = { group = "io.insert-koin", name = "koin-android-test", version.ref = "koin" }
+timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Harden build config and add debug tooling (Timber, LeakCanary, StrictMode)

Files to change:
- app/build.gradle.kts
- gradle/libs.versions.toml
- app/src/main/java/dev/randheer094/dev/location/app/MockLocationApp.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/service/MockLocationService.kt

Goal:
Enforce CI signing safety, enable strict lint and compiler warnings, and wire Timber + LeakCanary + StrictMode for debug builds.

Acceptance criteria:
- In the release signing config block of app/build.gradle.kts (around line 67), when keystoreProperties is empty AND the CI environment variable is set (System.getenv("CI") != null), the build fails with a clear error message via error("...") instead of falling back to the debug keystore
- The debug keystore fallback remains intact for local builds (when CI env var is not set)
- versionCode remains 10 and versionName remains "1.0.0" with a brief comment confirming this is intentional for the first public upload
- A lint {} block is added inside the android {} block with abortOnError = true and warningsAsErrors = true
- allWarningsAsErrors is set to true inside kotlin.compilerOptions (add allWarningsAsErrors.set(true) alongside the existing jvmTarget)
- buildConfig = true is added to the existing buildFeatures {} block (alongside compose = true)
- Timber version and library alias are added to gradle/libs.versions.toml (com.jakewharton.timber:timber, version ~5.0.1)
- LeakCanary version and library alias are added to gradle/libs.versions.toml (com.squareup.leakcanary:leakcanary-android, version ~2.14)
- Timber is added as an implementation dependency in app/build.gradle.kts
- LeakCanary is added as a debugImplementation dependency in app/build.gradle.kts
- In MockLocationApp.onCreate, after the existing Koin initialization, add an if (BuildConfig.DEBUG) block that: plants Timber.DebugTree(), enables StrictMode thread policy with detectAll().penaltyLog().build(), and enables StrictMode VM policy with detectAll().penaltyLog().build()
- LeakCanary auto-installs via its ContentProvider when added as debugImplementation — no code initialization needed
- In MockLocationService.kt, the Log.w(TAG, "Failed to push mock location, stopping loop", it) call on line 125 is replaced with Timber.w(it, "Failed to push mock location, stopping loop")
- The android.util.Log import in MockLocationService.kt (line 8) is removed and replaced with import timber.log.Timber
- The TAG companion constant in MockLocationService.kt can be removed since Timber generates tags automatically, but may be kept if preferred
- Existing unit and instrumentation tests still pass
- Note: enabling allWarningsAsErrors and lint warningsAsErrors may surface new compiler/lint warnings that fail the build — fixing those is expected as part of this task or a fast follow-up

Out of scope:
- MockLocationScreen, SetupInstruction, or any composable changes
- UiState or UiStateMapper changes
- NotificationUtils changes
- AndroidManifest.xml changes
- kotlinx-collections-immutable or lifecycle-runtime-compose dependencies (separate task)

Context:
The project rules mandate several debug-build conventions that are not yet wired:
- build.md requires allWarningsAsErrors = true for Kotlin compilation and lint with abortOnError = true + warningsAsErrors = true
- performance.md requires LeakCanary in debug builds and StrictMode with penaltyLog() in Application.onCreate under debug
- style.md requires Timber (debug tree only in debug builds) and prohibits direct Log.* calls

MockLocationApp.kt currently initializes PermissionFlow.init(this) and startKoin in onCreate. Add the debug-only block after Koin initialization. The class will need imports for timber.log.Timber, android.os.StrictMode, and dev.randheer094.dev.location.BuildConfig.

For the CI signing check: the current code at lines 67-73 does signingConfig = if (keystoreProperties.isNotEmpty()) signingConfigs.getByName("release") else signingConfigs.getByName("debug"). Change the else branch to: if (System.getenv("CI") != null) error("Release signing requires keystore.properties on CI") else signingConfigs.getByName("debug").

For the version catalog entries, add under [versions] and [libraries] sections following the existing naming pattern (e.g. timber = "5.0.1" and timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }).

---

Jira: [ARC-205](https://randheercode.atlassian.net/browse/ARC-205)
