### PR TITLE
ARC-206: Adopt collectAsStateWithLifecycle and ImmutableList for Compose stability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,8 @@ dependencies {
     implementation(libs.permission.flow.android)
     implementation(libs.permission.flow.compose)
     implementation(libs.timber)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.kotlinx.collections.immutable)
     debugImplementation(libs.leakcanary.android)
 
     testImplementation(libs.junit)

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -29,7 +29,7 @@
         errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/wrapper/gradle-wrapper.properties"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/wrapper/gradle-wrapper.properties"
             line="4"
             column="17"/>
     </issue>
@@ -40,7 +40,7 @@
         errorLine1="agp = &quot;9.0.0&quot;"
         errorLine2="      ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="2"
             column="7"/>
     </issue>
@@ -51,9 +51,20 @@
         errorLine1="coreKtx = &quot;1.17.0&quot;"
         errorLine2="          ~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="4"
             column="11"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-compose than 2.9.3 is available: 2.10.0"
+        errorLine1="lifecycleRuntimeKtx = &quot;2.9.3&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
+            line="5"
+            column="23"/>
     </issue>
 
     <issue
@@ -62,7 +73,7 @@
         errorLine1="lifecycleRuntimeKtx = &quot;2.9.3&quot;"
         errorLine2="                      ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="5"
             column="23"/>
     </issue>
@@ -73,7 +84,7 @@
         errorLine1="activityCompose = &quot;1.10.1&quot;"
         errorLine2="                  ~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="6"
             column="19"/>
     </issue>
@@ -84,7 +95,7 @@
         errorLine1="composeBom = &quot;2025.08.01&quot;"
         errorLine2="             ~~~~~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="7"
             column="14"/>
     </issue>
@@ -95,7 +106,7 @@
         errorLine1="lifecycleViewModelCompose = &quot;2.9.3&quot;"
         errorLine2="                            ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="8"
             column="29"/>
     </issue>
@@ -106,7 +117,7 @@
         errorLine1="datastore = &quot;1.1.7&quot;"
         errorLine2="            ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="11"
             column="13"/>
     </issue>
@@ -117,7 +128,7 @@
         errorLine1="datastore = &quot;1.1.7&quot;"
         errorLine2="            ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="11"
             column="13"/>
     </issue>
@@ -128,7 +139,7 @@
         errorLine1="androidxTestRunner = &quot;1.6.2&quot;"
         errorLine2="                     ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="15"
             column="22"/>
     </issue>
@@ -139,7 +150,7 @@
         errorLine1="androidxTestExtJunit = &quot;1.2.1&quot;"
         errorLine2="                       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="16"
             column="24"/>
     </issue>
@@ -150,7 +161,7 @@
         errorLine1="androidxTestRules = &quot;1.6.1&quot;"
         errorLine2="                    ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="17"
             column="21"/>
     </issue>
@@ -161,7 +172,7 @@
         errorLine1="androidxTestCore = &quot;1.6.1&quot;"
         errorLine2="                   ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="18"
             column="20"/>
     </issue>
@@ -172,7 +183,7 @@
         errorLine1="espresso = &quot;3.6.1&quot;"
         errorLine2="           ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="19"
             column="12"/>
     </issue>
@@ -183,7 +194,7 @@
         errorLine1="kotlin = &quot;2.2.10&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="3"
             column="10"/>
     </issue>
@@ -194,7 +205,7 @@
         errorLine1="kotlin = &quot;2.2.10&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="3"
             column="10"/>
     </issue>
@@ -205,7 +216,7 @@
         errorLine1="kotlin = &quot;2.2.10&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="3"
             column="10"/>
     </issue>
@@ -216,7 +227,7 @@
         errorLine1="kotlinSerialization = &quot;1.9.0&quot;"
         errorLine2="                      ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="9"
             column="23"/>
     </issue>
@@ -227,7 +238,7 @@
         errorLine1="koin = &quot;4.1.1&quot;"
         errorLine2="       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="10"
             column="8"/>
     </issue>
@@ -238,7 +249,7 @@
         errorLine1="koin = &quot;4.1.1&quot;"
         errorLine2="       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="10"
             column="8"/>
     </issue>
@@ -249,7 +260,7 @@
         errorLine1="koin = &quot;4.1.1&quot;"
         errorLine2="       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="10"
             column="8"/>
     </issue>
@@ -260,7 +271,7 @@
         errorLine1="koin = &quot;4.1.1&quot;"
         errorLine2="       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="10"
             column="8"/>
     </issue>
@@ -271,7 +282,7 @@
         errorLine1="koin = &quot;4.1.1&quot;"
         errorLine2="       ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="10"
             column="8"/>
     </issue>
@@ -282,9 +293,20 @@
         errorLine1="kotlinxCoroutines = &quot;1.9.0&quot;"
         errorLine2="                    ~~~~~~~">
         <location
-            file="$HOME/.velocity/workspace/ARC-205/gradle/libs.versions.toml"
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
             line="14"
             column="21"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-collections-immutable than 0.3.8 is available: 0.4.0"
+        errorLine1="kotlinxCollectionsImmutable = &quot;0.3.8&quot;"
+        errorLine2="                              ~~~~~~~">
+        <location
+            file="$HOME/.velocity/workspace/ARC-206/gradle/libs.versions.toml"
+            line="24"
+            column="31"/>
     </issue>
 
     <issue

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/BroadcastingHero.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/BroadcastingHero.kt
@@ -34,6 +34,7 @@ import dev.randheer094.dev.location.presentation.theme.JetBrainsMonoFamily
 import dev.randheer094.dev.location.presentation.theme.LocalMockColors
 import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
 import kotlin.math.abs
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun BroadcastingHero(
@@ -174,7 +175,7 @@ private fun BroadcastingHeroLightPreview() {
                 showInstructions = false,
                 status = true,
                 hasNotificationPermission = true,
-                items = emptyList(),
+                items = persistentListOf(),
                 elapsedLabel = "00:05:30",
                 selected = MockLocation(name = "Singapore, Singapore", lat = 1.3521, long = 103.8198),
             ),
@@ -192,7 +193,7 @@ private fun BroadcastingHeroDarkPreview() {
                 showInstructions = false,
                 status = true,
                 hasNotificationPermission = true,
-                items = emptyList(),
+                items = persistentListOf(),
                 elapsedLabel = "01:22:05",
                 selected = MockLocation(name = "Singapore, Singapore", lat = 1.3521, long = 103.8198),
             ),

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/IdleHero.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/IdleHero.kt
@@ -32,6 +32,7 @@ import dev.randheer094.dev.location.presentation.mocklocation.state.UiState
 import dev.randheer094.dev.location.presentation.theme.InterFamily
 import dev.randheer094.dev.location.presentation.theme.LocalMockColors
 import dev.randheer094.dev.location.presentation.theme.MockLocationTheme
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun IdleHero(
@@ -149,7 +150,7 @@ private fun IdleHeroWithLocationLightPreview() {
                 showInstructions = false,
                 status = false,
                 hasNotificationPermission = true,
-                items = emptyList(),
+                items = persistentListOf(),
                 elapsedLabel = "",
                 selected = MockLocation(name = "Singapore, Singapore", lat = 1.3521, long = 103.8198),
             ),
@@ -167,7 +168,7 @@ private fun IdleHeroNoLocationDarkPreview() {
                 showInstructions = false,
                 status = false,
                 hasNotificationPermission = true,
-                items = emptyList(),
+                items = persistentListOf(),
                 elapsedLabel = "",
                 selected = null,
             ),

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
@@ -40,8 +40,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -76,7 +76,7 @@ import org.koin.androidx.compose.koinViewModel
 fun MockLocationScreen(
     viewModel: MockLocationViewModel = koinViewModel(),
 ) {
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     val service = useMockLocationService()

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
@@ -1,6 +1,8 @@
 package dev.randheer094.dev.location.presentation.mocklocation.state
 
 import dev.randheer094.dev.location.domain.MockLocation
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 sealed interface UiItem
 
@@ -28,7 +30,7 @@ data class UiState(
     val showInstructions: Boolean,
     val status: Boolean,
     val hasNotificationPermission: Boolean,
-    val items: List<UiItem>,
+    val items: ImmutableList<UiItem>,
     val elapsedLabel: String = "",
     val selected: MockLocation? = null,
     val sortOrder: SortOrder = SortOrder.A_TO_Z,
@@ -38,7 +40,7 @@ data class UiState(
             showInstructions = false,
             status = false,
             hasNotificationPermission = false,
-            items = emptyList(),
+            items = persistentListOf(),
             elapsedLabel = "",
             selected = null,
             sortOrder = SortOrder.A_TO_Z,

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt
@@ -1,6 +1,7 @@
 package dev.randheer094.dev.location.presentation.mocklocation.state
 
 import dev.randheer094.dev.location.domain.MockLocation
+import kotlinx.collections.immutable.toImmutableList
 
 object UiStateMapper {
 
@@ -24,7 +25,7 @@ object UiStateMapper {
                 add(SectionHeader.SelectLocations)
             }
             addAll(sortedLocations.map { Location(it) })
-        }
+        }.toImmutableList()
 
         return UiState(
             showInstructions = showInstructions,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ androidxArchCoreTesting = "2.2.0"
 androidxUiAutomator = "2.3.0"
 timber = "5.0.1"
 leakcanary = "2.14"
+kotlinxCollectionsImmutable = "0.3.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -56,6 +57,8 @@ koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin"
 koin-android-test = { group = "io.insert-koin", name = "koin-android-test", version.ref = "koin" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Adopt collectAsStateWithLifecycle and ImmutableList for Compose stability

Files to change:
- app/build.gradle.kts
- gradle/libs.versions.toml
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/composable/MockLocationScreen.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiState.kt
- app/src/main/java/dev/randheer094/dev/location/presentation/mocklocation/state/UiStateMapper.kt

Goal:
Stop the 1Hz timer flow from ticking when the activity is stopped, and eliminate unnecessary recomposition of the entire location list every second by making UiState.items a Compose-stable type.

Acceptance criteria:
- lifecycle-runtime-compose is added to gradle/libs.versions.toml using the existing lifecycleRuntimeKtx version ref (2.9.3) and added as an implementation dependency in app/build.gradle.kts (e.g. alias: androidx-lifecycle-runtime-compose, coordinates: group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx")
- kotlinx-collections-immutable is added to gradle/libs.versions.toml and app/build.gradle.kts as an implementation dependency (e.g. group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version ~0.3.8)
- In MockLocationScreen.kt, collectAsState() on line 79 is replaced with collectAsStateWithLifecycle(); the import changes from androidx.compose.runtime.collectAsState to androidx.lifecycle.compose.collectAsStateWithLifecycle
- UiState.items type changes from List<UiItem> to ImmutableList<UiItem> (import kotlinx.collections.immutable.ImmutableList)
- UiState.Empty.items changes from emptyList() to persistentListOf() (import kotlinx.collections.immutable.persistentListOf)
- In UiStateMapper.mapToUiState, the buildList { ... } result is converted via .toImmutableList() before being passed to the UiState constructor (import kotlinx.collections.immutable.toImmutableList)
- Existing JVM unit tests for UiStateMapper still pass — the tests use standard List operations (size, indexing, filterIsInstance, assertEquals with listOf) which all work transparently on ImmutableList since it extends List
- Existing instrumentation tests still pass

Out of scope:
- Service or ViewModel changes
- NotificationUtils changes
- contentDescription fixes (already handled in a prior task)
- Timber, LeakCanary, StrictMode, or any debug tooling (already handled in a prior task)
- Lint configuration or CI signing changes (already handled in a prior task)

Context:
The architecture.md rule states: "Composables consume state via viewModel.state.collectAsStateWithLifecycle() — never plain collectAsState" and "State types are stable: data classes with immutable fields and kotlinx.collections.immutable collections (ImmutableList, PersistentList) — never mutable List<T> in State."

Currently MockLocationScreen.kt line 79 uses collectAsState(), which means the ViewModel's StateFlow (including a 1Hz elapsed-time ticker) keeps emitting while the activity is stopped. Switching to collectAsStateWithLifecycle() stops collection when the lifecycle drops below STARTED.

UiState.items is currently List<UiItem> (Kotlin's mutable List interface). Compose's stability system treats List<T> as unstable, so even if the list contents haven't changed, Compose will recompose any composable that reads it. Combined with the 1Hz ticker updating elapsedLabel, this recomposes the entire LazyColumn every second. Changing to ImmutableList<UiItem> from kotlinx-collections-immutable marks the field as stable, enabling Compose to skip recomposition when the list hasn't actually changed. This is the biggest performance win in the app.

The UiStateMapper.mapToUiState function uses buildList { ... } which returns kotlin.collections.List. Append .toImmutableList() to the buildList result. For UiState.Empty, replace emptyList() with persistentListOf() which returns an empty PersistentList (a subtype of ImmutableList).

The existing UiStateMapperTest.kt has 20 tests that assert on state.items using standard List operations. These all work transparently on ImmutableList since ImmutableList extends kotlin.collections.List. No test changes should be needed, but verify by running ./gradlew :app:testDebugUnitTest.

---

Jira: [ARC-206](https://randheercode.atlassian.net/browse/ARC-206)
