### PR TITLE
Gate setup wizard on live mock-app authorization

### DIFF
--- a/.claude/skills/run-android-e2e/SKILL.md
+++ b/.claude/skills/run-android-e2e/SKILL.md
@@ -15,18 +15,24 @@ runbooks executed via the `velocity-test-mobile` MCP server
 Run all three. Any failure: stop, report, do **not** start tests. The skill
 does not boot the emulator or build the APK on the user's behalf.
 
+All three checks go through MCP tools or the gradle wrapper — no raw
+`adb` calls, no absolute SDK paths, so the skill is portable across
+machines and does not trip permission prompts.
+
 1. **MCP connected.** `ToolSearch select:mcp__velocity-test-mobile__app_launch`
    returns a schema. Failure: `velocity-test-mobile` is not reachable — ask
    the user to check `claude mcp list`.
-2. **Emulator booted.** Bash `adb devices -l` shows at least one
-   `emulator-*` line in state `device`. Failure: ask the user to run
-   `android emulator start <avd>`.
+2. **Emulator booted.** `mcp__velocity-test-mobile__device_list` returns
+   at least one device. Failure: ask the user to run
+   `android emulator start <avd>` (the `android` CLI is on PATH for
+   this project).
 3. **Debug APK installed.** `mcp__velocity-test-mobile__app_list` contains
    `dev.randheer094.dev.location.debug`. Failure: ask the user to run
    ```bash
-   ./gradlew :app:assembleDebug
-   adb install -r -t -g app/build/outputs/apk/debug/app-debug.apk
+   ./gradlew :app:installDebug
    ```
+   (assembles + installs in one step; uses the gradle wrapper, no SDK
+   path dependency).
 
 ## Mapping user requests → what to run
 

--- a/.claude/skills/run-android-e2e/fixtures/device-setup.md
+++ b/.claude/skills/run-android-e2e/fixtures/device-setup.md
@@ -7,8 +7,12 @@ Per-test reset and launch. Run before **every** test in `tests/`. Mirrors the
 ## Why this exists
 
 `app_clear_data` wipes DataStore + runtime perms; granting POST_NOTIFICATIONS
-and mock-app appops _before_ launch ensures the app's startup checks see the
-mock-app authorised, so we never see a transient wizard frame.
+and mock-app appops _before_ launch lets the app's setup-instruction gate
+(`SetupInstructionStatusUseCase`) read `MODE_ALLOWED` on the first DataStore
+emission and skip the wizard. The gate combines a stored "force-show" flag
+(default `false`) with a live `AppOpsManager` check, so the wizard is hidden
+on cold launch when appops is allowed and shown otherwise — no "check again"
+tap required for the happy path.
 
 `activity_start MainActivity` after `app_launch` defeats LeakCanary's
 `CATEGORY_LAUNCHER` activity, which can win launcher resolution after a leaky

--- a/.claude/skills/run-android-e2e/fixtures/home.md
+++ b/.claude/skills/run-android-e2e/fixtures/home.md
@@ -12,8 +12,10 @@ Up to 3 attempts:
 
 1. Run `ensureForegroundIsOurApp` (see `device-setup.md`).
 2. **MCP:** `wait_for_idle` (give recomposition a beat to settle).
-3. **MCP:** check `find_node(text = "I've done this — check again")` with a
-   short timeout — if visible, `click` it.
+3. **MCP:** check `find_node(textContains = "check again")` with a short
+   timeout — if visible, `click` it. (Matches the curly-apostrophe CTA
+   defined in `selectors.md → checkAgainCta` without forcing every
+   caller to type U+2019; `textContains` is unambiguous on this screen.)
 4. **MCP:** `wait_until_visible(text = "Mock location off", timeout_ms = 5000)`.
    If satisfied → return.
 5. After 3 unsuccessful attempts, **assert** `assert_visible(text = "Mock location off")` — fail with a clear error.

--- a/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/di/MockLocationModules.kt
@@ -1,5 +1,6 @@
 package dev.randheer094.dev.location.di
 
+import android.app.AppOpsManager
 import android.content.Context
 import android.location.LocationManager
 import androidx.datastore.core.DataStore
@@ -16,6 +17,7 @@ import dev.randheer094.dev.location.presentation.mocklocation.MockLocationViewMo
 import dev.randheer094.dev.location.presentation.mocklocation.state.UiStateMapper
 import dev.randheer094.dev.location.presentation.service.MockLocationServiceStarter
 import dev.randheer094.dev.location.presentation.utils.LocationUtils
+import dev.randheer094.dev.location.presentation.utils.MockAppAuthorizationUtils
 import dev.randheer094.dev.location.presentation.utils.NotificationUtils
 import dev.randheer094.dev.location.presentation.utils.PermissionUtils
 import dev.shreyaspatil.permissionFlow.PermissionFlow
@@ -43,7 +45,10 @@ val appModule = module {
     factory { SelectMockLocationUseCase(get(), get()) }
     factory { SelectedMockLocationUseCase(get(), get()) }
     factory { SetSetupInstructionStatusUseCase(get()) }
-    factory { SetupInstructionStatusUseCase(get()) }
+    factory {
+        val auth: MockAppAuthorizationUtils = get()
+        SetupInstructionStatusUseCase(get(), auth::isAuthorized)
+    }
 
     // UiStateMapper is now an object, no need to instantiate
     single { UiStateMapper }
@@ -62,5 +67,9 @@ val appModule = module {
     single {
         get<Context>().getSystemService(Context.LOCATION_SERVICE) as LocationManager
     }
+    single {
+        get<Context>().getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+    }
+    single { MockAppAuthorizationUtils(get(), get()) }
     single { PermissionFlow.getInstance() }
 }

--- a/app/src/main/java/dev/randheer094/dev/location/domain/SetupInstructionStatusUseCase.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/domain/SetupInstructionStatusUseCase.kt
@@ -11,9 +11,11 @@ import kotlinx.coroutines.flow.map
 
 class SetupInstructionStatusUseCase(
     private val dataStore: DataStore<Preferences>,
+    private val isMockAppAuthorized: () -> Boolean,
 ) {
     fun execute(): Flow<Boolean> = dataStore.data
-        .map { it[SETUP_INSTRUCTION_STATUS] ?: true }
+        .map { it[SETUP_INSTRUCTION_STATUS] ?: false }
+        .map { forceShow -> forceShow || !isMockAppAuthorized() }
         .distinctUntilChanged()
         .catch { emit(true) }
         .flowOn(Dispatchers.IO)

--- a/app/src/main/java/dev/randheer094/dev/location/presentation/utils/MockAppAuthorizationUtils.kt
+++ b/app/src/main/java/dev/randheer094/dev/location/presentation/utils/MockAppAuthorizationUtils.kt
@@ -1,0 +1,29 @@
+package dev.randheer094.dev.location.presentation.utils
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.os.Build
+import android.os.Process
+
+class MockAppAuthorizationUtils(
+    private val context: Context,
+    private val appOpsManager: AppOpsManager,
+) {
+    @Suppress("DEPRECATION")
+    fun isAuthorized(): Boolean {
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            appOpsManager.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_MOCK_LOCATION,
+                Process.myUid(),
+                context.packageName,
+            )
+        } else {
+            appOpsManager.checkOpNoThrow(
+                AppOpsManager.OPSTR_MOCK_LOCATION,
+                Process.myUid(),
+                context.packageName,
+            )
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+}

--- a/app/src/test/java/dev/randheer094/dev/location/domain/SetupInstructionStatusUseCaseTest.kt
+++ b/app/src/test/java/dev/randheer094/dev/location/domain/SetupInstructionStatusUseCaseTest.kt
@@ -1,0 +1,74 @@
+package dev.randheer094.dev.location.domain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SetupInstructionStatusUseCaseTest {
+
+    @Test
+    fun `wizard hidden when authorised and stored flag missing`() = runTest {
+        val useCase = SetupInstructionStatusUseCase(
+            dataStore = FakePreferenceDataStore(),
+            isMockAppAuthorized = { true },
+        )
+        assertEquals(false, useCase.execute().first())
+    }
+
+    @Test
+    fun `wizard shown when not authorised even if stored flag missing`() = runTest {
+        val useCase = SetupInstructionStatusUseCase(
+            dataStore = FakePreferenceDataStore(),
+            isMockAppAuthorized = { false },
+        )
+        assertEquals(true, useCase.execute().first())
+    }
+
+    @Test
+    fun `stored true forces wizard regardless of authorisation`() = runTest {
+        val initial = mutablePreferencesOf().apply { set(SETUP_INSTRUCTION_STATUS, true) }
+        val useCase = SetupInstructionStatusUseCase(
+            dataStore = FakePreferenceDataStore(initial),
+            isMockAppAuthorized = { true },
+        )
+        assertEquals(true, useCase.execute().first())
+    }
+
+    @Test
+    fun `stored false hides wizard when authorised`() = runTest {
+        val initial = mutablePreferencesOf().apply { set(SETUP_INSTRUCTION_STATUS, false) }
+        val useCase = SetupInstructionStatusUseCase(
+            dataStore = FakePreferenceDataStore(initial),
+            isMockAppAuthorized = { true },
+        )
+        assertEquals(false, useCase.execute().first())
+    }
+
+    @Test
+    fun `stored false still shows wizard when authorisation lost`() = runTest {
+        val initial = mutablePreferencesOf().apply { set(SETUP_INSTRUCTION_STATUS, false) }
+        val useCase = SetupInstructionStatusUseCase(
+            dataStore = FakePreferenceDataStore(initial),
+            isMockAppAuthorized = { false },
+        )
+        assertEquals(true, useCase.execute().first())
+    }
+}
+
+private class FakePreferenceDataStore(
+    initial: Preferences = emptyPreferences(),
+) : DataStore<Preferences> {
+    private val state = MutableStateFlow(initial)
+    override val data: Flow<Preferences> = state
+    override suspend fun updateData(
+        transform: suspend (Preferences) -> Preferences,
+    ): Preferences = state.updateAndGet { transform(it) }
+}


### PR DESCRIPTION
## Summary

- Setup wizard now hides as soon as the user authorises the app from Developer Options, instead of requiring the stored "force-show" flag to be flipped. Combines a stored flag (default `false`) with a live `AppOpsManager.checkOpNoThrow(android:mock_location)` check.
- New `MockAppAuthorizationUtils` wraps the appops API across pre-Q and Q+ codepaths.
- Tightens the `run-android-e2e` skill preflight: `mcp__velocity-test-mobile__device_list` instead of raw `adb`, `:app:installDebug` instead of separate assemble + install, plus inline docs explaining the new gate so future runbook readers understand why the appops grant skips the wizard.

## Test plan

- [x] JVM unit tests cover all four force-show / authorisation combinations (`SetupInstructionStatusUseCaseTest`).
- [x] Full e2e suite (17/17) green against the debug build via `run-android-e2e` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)